### PR TITLE
fix: bump Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.23'
   DOCKER_BUILDX_VERSION: 'v0.9.1'
 
   # Common users. We can't run a step 'if secrets.XXX != ""' but we can run a

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/statnett/provider-cloudian
 
-go 1.21
+go 1.23.0
 
 require (
 	github.com/crossplane/crossplane-runtime v1.16.0


### PR DESCRIPTION
Trying to bump Go version first. Hopefully this might fix some of the failing Renovate PRs.