### PR TITLE
ci: bump golang-ci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
 env:
   # Common versions
   GO_VERSION: '1.21'
-  GOLANGCI_VERSION: 'v1.54.0'
   DOCKER_BUILDX_VERSION: 'v0.9.1'
 
   # Common users. We can't run a step 'if secrets.XXX != ""' but we can run a
@@ -75,7 +74,9 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: ${{ env.GOLANGCI_VERSION }}
+          # renovate: datasource=go depName=github.com/golangci/golangci-lint
+          version: v1.62.2
+          args: --timeout 5m
 
   check-diff:
     runs-on: ubuntu-24.04

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cover.out
 .vscode
 .idea
 .DS_Store
+/*.iml


### PR DESCRIPTION
Ok, this isn't easy. Trying to bump golang-ci-lint version to unblock new Go version.