### PR TITLE
fix: correct cloudian-verb for create and update group

### DIFF
--- a/internal/sdk/cloudian/sdk.go
+++ b/internal/sdk/cloudian/sdk.go
@@ -173,7 +173,7 @@ func (client Client) CreateGroup(ctx context.Context, group Group) error {
 		return fmt.Errorf("error marshaling JSON: %w", err)
 	}
 
-	req, err := client.newRequest(ctx, url, http.MethodPost, jsonData)
+	req, err := client.newRequest(ctx, url, http.MethodPut, jsonData)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
@@ -196,7 +196,7 @@ func (client Client) UpdateGroup(ctx context.Context, group Group) error {
 	}
 
 	// Create a context with a timeout
-	req, err := client.newRequest(ctx, url, http.MethodPut, jsonData)
+	req, err := client.newRequest(ctx, url, http.MethodPost, jsonData)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}


### PR DESCRIPTION
Cloudian API wants PUT for create and POST for group update