### PR TITLE
fix: contain entire auth header in ProviderConfig

### DIFF
--- a/internal/controller/group/group.go
+++ b/internal/controller/group/group.go
@@ -51,7 +51,7 @@ const (
 type NoOpService struct{}
 
 var (
-	newCloudianService = func(providerConfig *apisv1alpha1.ProviderConfig, authHeader []byte) (*cloudian.Client, error) {
+	newCloudianService = func(providerConfig *apisv1alpha1.ProviderConfig, authHeader string) (*cloudian.Client, error) {
 		// FIXME: Don't require InsecureSkipVerify
 		return cloudian.NewClient(providerConfig.Spec.Endpoint, true, authHeader), nil
 	}
@@ -90,7 +90,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 type connector struct {
 	kube         client.Client
 	usage        resource.Tracker
-	newServiceFn func(providerConfig *apisv1alpha1.ProviderConfig, authHeader []byte) (*cloudian.Client, error)
+	newServiceFn func(providerConfig *apisv1alpha1.ProviderConfig, authHeader string) (*cloudian.Client, error)
 }
 
 // Connect typically produces an ExternalClient by:
@@ -119,7 +119,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errGetCreds)
 	}
 
-	svc, err := c.newServiceFn(pc, authHeader)
+	svc, err := c.newServiceFn(pc, string(authHeader))
 	if err != nil {
 		return nil, errors.Wrap(err, errNewClient)
 	}

--- a/internal/sdk/cloudian/sdk.go
+++ b/internal/sdk/cloudian/sdk.go
@@ -15,7 +15,7 @@ import (
 type Client struct {
 	baseURL    string
 	httpClient *http.Client
-	authHeader []byte
+	authHeader string
 }
 
 type Group struct {
@@ -41,7 +41,7 @@ type User struct {
 
 var ErrNotFound = errors.New("not found")
 
-func NewClient(baseUrl string, tlsInsecureSkipVerify bool, authHeader []byte) *Client {
+func NewClient(baseUrl string, tlsInsecureSkipVerify bool, authHeader string) *Client {
 	return &Client{
 		baseURL: baseUrl,
 		httpClient: &http.Client{Transport: &http.Transport{
@@ -258,7 +258,7 @@ func (client Client) newRequest(ctx context.Context, url string, method string, 
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", string(client.authHeader))
+	req.Header.Set("Authorization", client.authHeader)
 
 	return req, nil
 }


### PR DESCRIPTION
Will require a secret configured like so

```
export basicauth="Bearer $(echo "myuser_mykey" | base64)"
kubectl create secret -n my-namespace generic my-secret --from-literal basicauth="$basicauth"
```