### PR TITLE
chore: remove generated observable field from Group

### DIFF
--- a/apis/user/v1alpha1/group_types.go
+++ b/apis/user/v1alpha1/group_types.go
@@ -65,7 +65,6 @@ type GroupParameters struct {
 
 // GroupObservation are the observable fields of a Group.
 type GroupObservation struct {
-	ObservableField string `json:"observableField,omitempty"`
 }
 
 // A GroupSpec defines the desired state of a Group.

--- a/package/crds/user.cloudian.crossplane.io_groups.yaml
+++ b/package/crds/user.cloudian.crossplane.io_groups.yaml
@@ -292,9 +292,6 @@ spec:
             properties:
               atProvider:
                 description: GroupObservation are the observable fields of a Group.
-                properties:
-                  observableField:
-                    type: string
                 type: object
               conditions:
                 description: Conditions of the resource.


### PR DESCRIPTION
Not, and will never be, in use with that name