### PR TITLE
ci: migrate deprecated golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,10 @@
 run:
-  deadline: 2m
-
-  skip-files:
-  - "zz_generated\\..+\\.go$"
+  timeout: 5m
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
+  formats:
+  - format: colored-line-number
 
 linters-settings:
   errcheck:
@@ -21,7 +19,7 @@ linters-settings:
     # [deprecated] comma-separated list of pairs of the form pkg:regex
     # the regex is used to ignore names within pkg. (default "fmt:.*").
     # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io/ioutil:^Read.*
+    exclude-functions: fmt:.*,io/ioutil:^Read.*
 
   govet:
     # report about shadowed variables
@@ -104,17 +102,19 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
-    - govet
-    - gocyclo
-    - gocritic
     - goconst
-    - goimports
+    - gocritic
+    - gocyclo
     - gofmt  # We enable this as well as goimports for its simplify mode.
-    - prealloc
-    - unconvert
+    - goimports
+    - gosimple
+    - govet
     - misspell
     - nakedret
+    - prealloc
+    - staticcheck
+    - unconvert
+    - unused
 
   presets:
     - bugs
@@ -123,6 +123,9 @@ linters:
 
 
 issues:
+  exclude-files:
+    - "zz_generated\\..+\\.go$"
+
   # Excluding configuration per-path and per-linter
   exclude-rules:
     # Exclude some linters from running on tests files.


### PR DESCRIPTION
I noticed the golangci-lint run generated quite a few warnings. This fixes all.