### PR TITLE
refactor(sdk): perform request instead of only creating it

### DIFF
--- a/internal/sdk/cloudian/sdk.go
+++ b/internal/sdk/cloudian/sdk.go
@@ -154,7 +154,7 @@ func (client Client) ListUsers(ctx context.Context, groupId string, offsetUserId
 
 	resp, err := client.newRequest(ctx, http.MethodGet, "/user/list", params, nil)
 	if err != nil {
-		return nil, fmt.Errorf("GET list users failed: %w", err)
+		return nil, err
 	}
 
 	defer resp.Body.Close() // nolint:errcheck
@@ -194,7 +194,7 @@ func (client Client) DeleteUser(ctx context.Context, user User) error {
 	resp, err := client.newRequest(ctx, http.MethodDelete, "/user",
 		map[string]string{"groupId": user.GroupID, "userId": user.UserID}, nil)
 	if err != nil {
-		return fmt.Errorf("DELETE to cloudian /user got: %w", err)
+		return err
 	}
 	defer resp.Body.Close() // nolint:errcheck
 
@@ -216,7 +216,7 @@ func (client Client) CreateUser(ctx context.Context, user User) error {
 
 	resp, err := client.newRequest(ctx, http.MethodPut, "/user", nil, jsonData)
 	if err != nil {
-		return fmt.Errorf("PUT to cloudian /user: %w", err)
+		return err
 	}
 
 	return resp.Body.Close()
@@ -227,7 +227,7 @@ func (client Client) GetUserCredentials(ctx context.Context, user User) ([]Secur
 	resp, err := client.newRequest(ctx, http.MethodGet, "/user/credentials/list",
 		map[string]string{"groupId": user.GroupID, "userId": user.UserID}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error performing credentials request: %w", err)
+		return nil, err
 	}
 
 	defer resp.Body.Close() // nolint:errcheck
@@ -256,7 +256,6 @@ func (client Client) GetUserCredentials(ctx context.Context, user User) ([]Secur
 // Delete a group and all its members.
 func (client Client) DeleteGroupRecursive(ctx context.Context, groupId string) error {
 	users, err := client.ListUsers(ctx, groupId, nil)
-
 	if err != nil {
 		return fmt.Errorf("error listing users: %w", err)
 	}
@@ -275,7 +274,7 @@ func (client Client) DeleteGroup(ctx context.Context, groupId string) error {
 	resp, err := client.newRequest(ctx, http.MethodDelete, "/group",
 		map[string]string{"groupId": groupId}, nil)
 	if err != nil {
-		return fmt.Errorf("DELETE to cloudian /group got: %w", err)
+		return err
 	}
 
 	return resp.Body.Close()
@@ -290,7 +289,7 @@ func (client Client) CreateGroup(ctx context.Context, group Group) error {
 
 	resp, err := client.newRequest(ctx, http.MethodPut, "/group", nil, jsonData)
 	if err != nil {
-		return fmt.Errorf("POST to cloudian /group: %w", err)
+		return err
 	}
 
 	return resp.Body.Close()
@@ -306,7 +305,7 @@ func (client Client) UpdateGroup(ctx context.Context, group Group) error {
 	// Create a context with a timeout
 	resp, err := client.newRequest(ctx, http.MethodPost, "/group", nil, jsonData)
 	if err != nil {
-		return fmt.Errorf("PUT to cloudian /group: %w", err)
+		return err
 	}
 
 	return resp.Body.Close()
@@ -318,7 +317,7 @@ func (client Client) GetGroup(ctx context.Context, groupId string) (*Group, erro
 	resp, err := client.newRequest(ctx, http.MethodGet, "/group",
 		map[string]string{"groupId": groupId}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("GET error: %w", err)
+		return nil, err
 	}
 
 	defer resp.Body.Close() // nolint:errcheck

--- a/internal/sdk/cloudian/sdk.go
+++ b/internal/sdk/cloudian/sdk.go
@@ -152,7 +152,7 @@ func (client Client) ListUsers(ctx context.Context, groupId string, offsetUserId
 		params["offset"] = *offsetUserId
 	}
 
-	resp, err := client.newRequest(ctx, http.MethodGet, "/user/list", params, nil)
+	resp, err := client.doRequest(ctx, http.MethodGet, "/user/list", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (client Client) ListUsers(ctx context.Context, groupId string, offsetUserId
 
 // Delete a single user. Errors if the user does not exist.
 func (client Client) DeleteUser(ctx context.Context, user User) error {
-	resp, err := client.newRequest(ctx, http.MethodDelete, "/user",
+	resp, err := client.doRequest(ctx, http.MethodDelete, "/user",
 		map[string]string{"groupId": user.GroupID, "userId": user.UserID}, nil)
 	if err != nil {
 		return err
@@ -214,7 +214,7 @@ func (client Client) CreateUser(ctx context.Context, user User) error {
 		return fmt.Errorf("error marshaling JSON: %w", err)
 	}
 
-	resp, err := client.newRequest(ctx, http.MethodPut, "/user", nil, jsonData)
+	resp, err := client.doRequest(ctx, http.MethodPut, "/user", nil, jsonData)
 	if err != nil {
 		return err
 	}
@@ -224,7 +224,7 @@ func (client Client) CreateUser(ctx context.Context, user User) error {
 
 // GetUserCredentials fetches all the credentials of a user.
 func (client Client) GetUserCredentials(ctx context.Context, user User) ([]SecurityInfo, error) {
-	resp, err := client.newRequest(ctx, http.MethodGet, "/user/credentials/list",
+	resp, err := client.doRequest(ctx, http.MethodGet, "/user/credentials/list",
 		map[string]string{"groupId": user.GroupID, "userId": user.UserID}, nil)
 	if err != nil {
 		return nil, err
@@ -271,7 +271,7 @@ func (client Client) DeleteGroupRecursive(ctx context.Context, groupId string) e
 
 // Deletes a group if it is without members.
 func (client Client) DeleteGroup(ctx context.Context, groupId string) error {
-	resp, err := client.newRequest(ctx, http.MethodDelete, "/group",
+	resp, err := client.doRequest(ctx, http.MethodDelete, "/group",
 		map[string]string{"groupId": groupId}, nil)
 	if err != nil {
 		return err
@@ -287,7 +287,7 @@ func (client Client) CreateGroup(ctx context.Context, group Group) error {
 		return fmt.Errorf("error marshaling JSON: %w", err)
 	}
 
-	resp, err := client.newRequest(ctx, http.MethodPut, "/group", nil, jsonData)
+	resp, err := client.doRequest(ctx, http.MethodPut, "/group", nil, jsonData)
 	if err != nil {
 		return err
 	}
@@ -303,7 +303,7 @@ func (client Client) UpdateGroup(ctx context.Context, group Group) error {
 	}
 
 	// Create a context with a timeout
-	resp, err := client.newRequest(ctx, http.MethodPost, "/group", nil, jsonData)
+	resp, err := client.doRequest(ctx, http.MethodPost, "/group", nil, jsonData)
 	if err != nil {
 		return err
 	}
@@ -314,7 +314,7 @@ func (client Client) UpdateGroup(ctx context.Context, group Group) error {
 // Get a group. Returns an error even in the case of a group not found.
 // This error can then be checked against ErrNotFound: errors.Is(err, ErrNotFound)
 func (client Client) GetGroup(ctx context.Context, groupId string) (*Group, error) {
-	resp, err := client.newRequest(ctx, http.MethodGet, "/group",
+	resp, err := client.doRequest(ctx, http.MethodGet, "/group",
 		map[string]string{"groupId": groupId}, nil)
 	if err != nil {
 		return nil, err
@@ -344,7 +344,7 @@ func (client Client) GetGroup(ctx context.Context, groupId string) (*Group, erro
 	}
 }
 
-func (client Client) newRequest(ctx context.Context, method string, url string, query map[string]string, body []byte) (*http.Response, error) {
+func (client Client) doRequest(ctx context.Context, method string, url string, query map[string]string, body []byte) (*http.Response, error) {
 	var buffer io.Reader = nil
 	if body != nil {
 		buffer = bytes.NewBuffer(body)


### PR DESCRIPTION
As creation of request is always followed by doing that request.

The error from `Do` also includes _method_ and _url_, so it seems we can skip wrapping the error.  
Example `Get "http://kasfjlkasjflkas.ar/user/list?groupId=tenant1&limit=100&userStatus=all&userType=all": dial tcp: lookup kasfjlkasjflkas.ar on 127.0.0.11:53: no such host`