### PR TITLE
refactor: introduce resty to lift abstraction level in Cloudian SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/crossplane/crossplane-runtime v1.18.0
 	github.com/crossplane/crossplane-tools v0.0.0-20240522174801-1ad3d4c87f21
+	github.com/go-resty/resty/v2 v2.16.3
 	github.com/google/go-cmp v0.6.0
 	github.com/pkg/errors v0.9.1
 	k8s.io/apimachinery v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/go-openapi/jsonreference v0.21.0 h1:Rs+Y7hSXT83Jacb7kFyjn4ijOuVGSvOdF
 github.com/go-openapi/jsonreference v0.21.0/go.mod h1:LmZmgsrTkVg9LG4EaHeY8cBDslNPMo06cago5JNLkm4=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
+github.com/go-resty/resty/v2 v2.16.3 h1:zacNT7lt4b8M/io2Ahj6yPypL7bqx9n1iprfQuodV+E=
+github.com/go-resty/resty/v2 v2.16.3/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gobuffalo/flect v1.0.3 h1:xeWBM2nui+qnVvNM4S3foBhCAL2XgPU+a7FdpelbTq4=

--- a/internal/sdk/cloudian/sdk.go
+++ b/internal/sdk/cloudian/sdk.go
@@ -1,21 +1,17 @@
 package cloudian
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"strconv"
+
+	"github.com/go-resty/resty/v2"
 )
 
 type Client struct {
-	baseURL    string
-	httpClient *http.Client
-	authHeader string
+	client *resty.Client
 }
 
 type Group struct {
@@ -119,17 +115,15 @@ var ErrNotFound = errors.New("not found")
 // WithInsecureTLSVerify skips the TLS validation of the server certificate when `insecure` is true.
 func WithInsecureTLSVerify(insecure bool) func(*Client) {
 	return func(c *Client) {
-		c.httpClient = &http.Client{Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure}, // nolint:gosec
-		}}
+		c.client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: insecure}) //nolint:gosec
 	}
 }
 
 func NewClient(baseURL string, authHeader string, opts ...func(*Client)) *Client {
 	c := &Client{
-		baseURL:    baseURL,
-		httpClient: http.DefaultClient,
-		authHeader: authHeader,
+		client: resty.New().
+			SetBaseURL(baseURL).
+			SetHeader("Authorization", authHeader),
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -139,7 +133,7 @@ func NewClient(baseURL string, authHeader string, opts ...func(*Client)) *Client
 
 // List all users of a group.
 func (client Client) ListUsers(ctx context.Context, groupId string, offsetUserId *string) ([]User, error) {
-	var retVal []User
+	var retVal, users []User
 
 	limit := 100
 	params := map[string]string{
@@ -152,21 +146,12 @@ func (client Client) ListUsers(ctx context.Context, groupId string, offsetUserId
 		params["offset"] = *offsetUserId
 	}
 
-	resp, err := client.doRequest(ctx, http.MethodGet, "/user/list", params, nil)
+	_, err := client.newRequest(ctx).
+		SetQueryParams(params).
+		SetResult(&users).
+		Get("/user/list")
 	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close() // nolint:errcheck
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("GET reading list users response body failed: %w", err)
-	}
-
-	var users []User
-	if err := json.Unmarshal(body, &users); err != nil {
-		return nil, fmt.Errorf("GET unmarshal users response body failed: %w", err)
+		return nil, fmt.Errorf("GET list users failed: %w", err)
 	}
 
 	retVal = append(retVal, users...)
@@ -190,141 +175,84 @@ func (client Client) ListUsers(ctx context.Context, groupId string, offsetUserId
 
 // Delete a single user. Errors if the user does not exist.
 func (client Client) DeleteUser(ctx context.Context, user User) error {
-	resp, err := client.doRequest(ctx, http.MethodDelete, "/user",
-		map[string]string{"groupId": user.GroupID, "userId": user.UserID}, nil)
+	resp, err := client.newRequest(ctx).
+		SetQueryParams(map[string]string{
+			"groupId": user.GroupID,
+			"userId":  user.UserID,
+		}).
+		Delete("/user")
 	if err != nil {
 		return err
 	}
 
-	defer resp.Body.Close() // nolint:errcheck
-
-	switch resp.StatusCode {
+	switch resp.StatusCode() {
 	case 200:
 		return nil
 	default:
-		return fmt.Errorf("DELETE unexpected status. Failure: %d", resp.StatusCode)
+		return fmt.Errorf("DELETE user unexpected status: %d, %w", resp.StatusCode(), err)
 	}
+
 }
 
 // Create a single user of type `User` into a groupId
 func (client Client) CreateUser(ctx context.Context, user User) error {
-	jsonData, err := json.Marshal(toInternalUser(user))
-	if err != nil {
-		return fmt.Errorf("error marshaling JSON: %w", err)
-	}
+	_, err := client.newRequest(ctx).
+		SetBody(toInternalUser(user)).
+		Put("/user")
 
-	resp, err := client.doRequest(ctx, http.MethodPut, "/user", nil, jsonData)
-	if err != nil {
-		return err
-	}
-
-	return resp.Body.Close()
+	return err
 }
 
 // CreateUserCredentials creates a new set of credentials for a user.
 func (client Client) CreateUserCredentials(ctx context.Context, user User) (*SecurityInfo, error) {
-	resp, err := client.doRequest(ctx, http.MethodPut, "/user/credentials",
-		map[string]string{"groupId": user.GroupID, "userId": user.UserID}, nil)
+	var securityInfo SecurityInfo
+	_, err := client.newRequest(ctx).
+		SetResult(&securityInfo).
+		SetBody(map[string]string{"groupId": user.GroupID, "userId": user.UserID}).
+		Put("/user/credentials")
 	if err != nil {
 		return nil, err
 	}
 
-	defer resp.Body.Close() // nolint:errcheck
-
-	switch resp.StatusCode {
-	case 200:
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error reading create credentials response: %w", err)
-		}
-
-		var securityInfo SecurityInfo
-		if err := json.Unmarshal(body, &securityInfo); err != nil {
-			return nil, fmt.Errorf("error parsing create credentials response: %w", err)
-		}
-
-		return &securityInfo, nil
-	default:
-		return nil, fmt.Errorf("error: create credentials unexpected status code: %d", resp.StatusCode)
-	}
+	return &securityInfo, nil
 }
 
-// GetUserCredentials fetches a set of credentials for a user.
+// GetUserCredentials fetches all the credentials of a user.
 func (client Client) GetUserCredentials(ctx context.Context, accessKey string) (*SecurityInfo, error) {
-	resp, err := client.doRequest(ctx, http.MethodGet, "/user/credentials",
-		map[string]string{"accessKey": accessKey}, nil)
+	var securityInfo SecurityInfo
+
+	resp, err := client.newRequest(ctx).
+		SetQueryParams(map[string]string{"accessKey": accessKey}).
+		SetResult(&securityInfo).
+		Get("/user/credentials")
 	if err != nil {
 		return nil, err
 	}
-
-	defer resp.Body.Close() // nolint:errcheck
-
-	switch resp.StatusCode {
+	switch resp.StatusCode() {
 	case 200:
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error reading get credentials response: %w", err)
-		}
-
-		var securityInfo SecurityInfo
-		if err := json.Unmarshal(body, &securityInfo); err != nil {
-			return nil, fmt.Errorf("error parsing get credentials response: %w", err)
-		}
-
 		return &securityInfo, nil
-	case 204:
-		return nil, ErrNotFound
-	default:
-		return nil, fmt.Errorf("error: get credentials unexpected status code: %d", resp.StatusCode)
-	}
-}
-
-// ListUserCredentials fetches all the credentials of a user.
-func (client Client) ListUserCredentials(ctx context.Context, user User) ([]SecurityInfo, error) {
-	resp, err := client.doRequest(ctx, http.MethodGet, "/user/credentials/list",
-		map[string]string{"groupId": user.GroupID, "userId": user.UserID}, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close() // nolint:errcheck
-
-	switch resp.StatusCode {
-	case 200:
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error reading list credentials response: %w", err)
-		}
-
-		var securityInfo []SecurityInfo
-		if err := json.Unmarshal(body, &securityInfo); err != nil {
-			return nil, fmt.Errorf("error parsing list credentials response: %w", err)
-		}
-
-		return securityInfo, nil
 	case 204:
 		// Cloudian-API returns 204 if no security credentials found
 		return nil, ErrNotFound
 	default:
-		return nil, fmt.Errorf("error: list credentials unexpected status code: %d", resp.StatusCode)
+		return nil, fmt.Errorf("error: list credentials unexpected status code: %d", resp.StatusCode())
 	}
 }
 
 // DeleteUserCredentials deletes a set of credentials for a user.
 func (client Client) DeleteUserCredentials(ctx context.Context, accessKey string) error {
-	resp, err := client.doRequest(ctx, http.MethodDelete, "/user/credentials",
-		map[string]string{"accessKey": accessKey}, nil)
+	resp, err := client.newRequest(ctx).
+		SetQueryParams(map[string]string{"accessKey": accessKey}).
+		Delete("/user/credentials")
 	if err != nil {
 		return err
 	}
 
-	defer resp.Body.Close() // nolint:errcheck
-
-	switch resp.StatusCode {
+	switch resp.StatusCode() {
 	case 200:
 		return nil
 	default:
-		return fmt.Errorf("DELETE unexpected status. Failure: %d", resp.StatusCode)
+		return fmt.Errorf("DELETE credentials unexpected status: %d, %w", resp.StatusCode(), err)
 	}
 }
 
@@ -346,75 +274,50 @@ func (client Client) DeleteGroupRecursive(ctx context.Context, groupId string) e
 
 // Deletes a group if it is without members.
 func (client Client) DeleteGroup(ctx context.Context, groupId string) error {
-	resp, err := client.doRequest(ctx, http.MethodDelete, "/group",
-		map[string]string{"groupId": groupId}, nil)
-	if err != nil {
-		return err
-	}
+	resp, err := client.newRequest(ctx).
+		SetQueryParams(map[string]string{"groupId": groupId}).
+		Delete("/group")
 
-	defer resp.Body.Close() // nolint:errcheck
-
-	switch resp.StatusCode {
+	switch resp.StatusCode() {
 	case 200:
 		return nil
 	default:
-		return fmt.Errorf("DELETE unexpected status. Failure: %d", resp.StatusCode)
+		return fmt.Errorf("DELETE group unexpected statusCode: %d, %w", resp.StatusCode(), err)
 	}
 }
 
 // Creates a group.
 func (client Client) CreateGroup(ctx context.Context, group Group) error {
-	jsonData, err := json.Marshal(toInternal(group))
-	if err != nil {
-		return fmt.Errorf("error marshaling JSON: %w", err)
-	}
+	_, err := client.newRequest(ctx).
+		SetBody(toInternal(group)).
+		Put("/group")
 
-	resp, err := client.doRequest(ctx, http.MethodPut, "/group", nil, jsonData)
-	if err != nil {
-		return err
-	}
-
-	return resp.Body.Close()
+	return err
 }
 
 // Updates a group if it does not exists.
 func (client Client) UpdateGroup(ctx context.Context, group Group) error {
-	jsonData, err := json.Marshal(toInternal(group))
-	if err != nil {
-		return fmt.Errorf("error marshaling JSON: %w", err)
-	}
+	_, err := client.newRequest(ctx).
+		SetBody(toInternal(group)).
+		Post("/group")
 
-	resp, err := client.doRequest(ctx, http.MethodPost, "/group", nil, jsonData)
-	if err != nil {
-		return err
-	}
-
-	return resp.Body.Close()
+	return err
 }
 
 // Get a group. Returns an error even in the case of a group not found.
 // This error can then be checked against ErrNotFound: errors.Is(err, ErrNotFound)
 func (client Client) GetGroup(ctx context.Context, groupId string) (*Group, error) {
-	resp, err := client.doRequest(ctx, http.MethodGet, "/group",
-		map[string]string{"groupId": groupId}, nil)
+	var group groupInternal
+	resp, err := client.newRequest(ctx).
+		SetQueryParams(map[string]string{"groupId": groupId}).
+		SetResult(&group).
+		Get("/group")
 	if err != nil {
 		return nil, err
 	}
 
-	defer resp.Body.Close() // nolint:errcheck
-
-	switch resp.StatusCode {
+	switch resp.StatusCode() {
 	case 200:
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("GET reading response body failed: %w", err)
-		}
-
-		var group groupInternal
-		if err := json.Unmarshal(body, &group); err != nil {
-			return nil, fmt.Errorf("GET unmarshal response body failed: %w", err)
-		}
-
 		retVal := fromInternal(group)
 		return &retVal, nil
 	case 204:
@@ -425,25 +328,9 @@ func (client Client) GetGroup(ctx context.Context, groupId string) (*Group, erro
 	}
 }
 
-func (client Client) doRequest(ctx context.Context, method string, url string, query map[string]string, body []byte) (*http.Response, error) {
-	var buffer io.Reader = nil
-	if body != nil {
-		buffer = bytes.NewBuffer(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, client.baseURL+url, buffer)
-	if err != nil {
-		return nil, fmt.Errorf("error creating request: %w", err)
-	}
-
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", client.authHeader)
-
-	q := req.URL.Query()
-	for k, v := range query {
-		q.Set(k, v)
-	}
-	req.URL.RawQuery = q.Encode()
-
-	return client.httpClient.Do(req)
+func (client Client) newRequest(ctx context.Context) *resty.Request {
+	return client.client.R().
+		SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		ForceContentType("application/json") // TODO figure out why this is needed
 }

--- a/internal/sdk/cloudian/sdk_test.go
+++ b/internal/sdk/cloudian/sdk_test.go
@@ -1,110 +1,16 @@
 package cloudian
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
-	"reflect"
-	"strings"
+	"net/http"
+	"net/http/httptest"
 	"testing"
-	"testing/quick"
+
+	"github.com/google/go-cmp/cmp"
 )
-
-func TestRealisticGroupSerialization(t *testing.T) {
-	jsonString := `{
-			"active": "true",
-			"groupId": "QA",
-			"groupName": "Quality Assurance Group",
-			"ldapEnabled": false,
-			"s3endpointshttp": ["ALL"],
-			"s3endpointshttps": ["ALL"],
-			"s3websiteendpoints": ["ALL"]
-		}`
-
-	var group groupInternal
-	err := json.Unmarshal([]byte(jsonString), &group)
-	if err != nil {
-		t.Errorf("Error deserializing from JSON: %v", err)
-	}
-
-	if group.GroupID != "QA" {
-		t.Errorf("Expected QA, got %v", group.GroupID)
-	}
-}
-
-func TestUnmarshalUsers(t *testing.T) {
-	jsonString := `[
-		{
-			"active": "true",
-			"address1": "",
-			"address2": "",
-			"canonicalUserId": "fd221552ff4ddc857d7a9ca316bb8344",
-			"city": "",
-			"country": "",
-			"emailAddr": "",
-			"fullName": "Glory Bee",
-			"groupId": "QA",
-			"ldapEnabled": false,
-			"phone": "",
-			"state": "",
-			"userId": "Glory",
-			"userType": "User",
-			"website": "",
-			"zip": ""
-		},
-		{
-			"active": "true",
-			"address1": "",
-			"address2": "",
-			"canonicalUserId": "bd0796cd9746ef9cc4ef656ddaacfac4",
-			"city": "",
-			"country": "",
-			"emailAddr": "",
-			"fullName": "John Thompson",
-			"groupId": "QA",
-			"ldapEnabled": false,
-			"phone": "",
-			"state": "",
-			"userId": "John",
-			"userType": "User",
-			"website": "",
-			"zip": ""
-			}]`
-
-	var users []User
-	err := json.Unmarshal([]byte(jsonString), &users)
-	if err != nil {
-		t.Errorf("Error deserializing users from JSON: %v", err)
-	}
-
-	if users[0].UserID != "Glory" {
-		t.Errorf("Expected Glory as the userId of first user, got %v", users[0].UserID)
-	}
-
-	if users[1].UserID != "John" {
-		t.Errorf("Expected John as the userId of second user, got %v", users[1].UserID)
-	}
-
-}
-
-func (group groupInternal) Generate(rand *rand.Rand, size int) reflect.Value {
-	return reflect.ValueOf(groupInternal{
-		Active:             "true",
-		GroupID:            randomString(16),
-		GroupName:          randomString(32),
-		LDAPEnabled:        true,
-		LDAPGroup:          randomString(8),
-		LDAPMatchAttribute: randomString(8),
-		LDAPSearch:         randomString(8),
-		LDAPSearchUserBase: randomString(8),
-		LDAPServerURL:      randomString(8),
-		LDAPUserDNTemplate: randomString(8),
-		S3EndpointsHTTP:    []string{randomString(8), randomString(8)},
-		S3EndpointsHTTPS:   []string{randomString(8), randomString(8)},
-		S3WebSiteEndpoints: []string{randomString(8), randomString(8)},
-	})
-}
 
 func TestGenericError(t *testing.T) {
 	err := errors.New("Random failure")
@@ -122,49 +28,98 @@ func TestWrappedErrNotFound(t *testing.T) {
 	}
 }
 
-func TestGroupSerialization(t *testing.T) {
-	f := func(group groupInternal) bool {
-		data, err := json.Marshal(group)
-		if err != nil {
-			return false
-		}
+func TestGetGroup(t *testing.T) {
+	cloudianClient, testServer := mockBy(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(groupInternal{GroupID: "QA", Active: "true"})
+	})
+	defer testServer.Close()
 
-		var deserialized groupInternal
-		if err = json.Unmarshal(data, &deserialized); err != nil {
-			return false
-		}
-
-		return reflect.DeepEqual(group, deserialized)
+	expected := Group{
+		GroupID: "QA",
+		Active:  true,
 	}
 
-	if err := quick.Check(f, nil); err != nil {
-		t.Error(err)
+	group, err := cloudianClient.GetGroup(context.TODO(), "QA")
+
+	if err != nil {
+		t.Errorf("Error getting group: %v", err)
+	}
+
+	if diff := cmp.Diff(expected, *group); diff != "" {
+		t.Errorf("GetGroup() mismatch (-want +got):\n%s", diff)
+	}
+
+}
+
+func TestGetGroupNotFound(t *testing.T) {
+	cloudianClient, testServer := mockBy(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer testServer.Close()
+
+	_, err := cloudianClient.GetGroup(context.TODO(), "QA")
+
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Expected error to be ErrNotFound")
 	}
 }
 
-func TestGroupToInternalRoundtrip(t *testing.T) {
-	f := func(group groupInternal) bool {
-		// Override fuzzed s3-endpoint entries with known values
-		group.S3EndpointsHTTP = []string{"ALL"}
-		group.S3EndpointsHTTPS = []string{"ALL"}
-		group.S3WebSiteEndpoints = []string{"ALL"}
+func TestCreateCredentials(t *testing.T) {
+	expected := SecurityInfo{AccessKey: "123", SecretKey: "abc"}
+	cloudianClient, testServer := mockBy(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(expected)
+	})
+	defer testServer.Close()
 
-		roundtrip := toInternal(fromInternal(group))
-		return reflect.DeepEqual(group, roundtrip)
+	credentials, err := cloudianClient.CreateUserCredentials(context.TODO(), User{GroupID: "QA", UserID: "user1"})
+
+	if err != nil {
+		t.Errorf("Error creating credentials: %v", err)
 	}
 
-	if err := quick.Check(f, nil); err != nil {
-		t.Error(err)
+	if diff := cmp.Diff(expected, *credentials); diff != "" {
+		t.Errorf("CreateUserCredentials() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
+func TestGetUserCredentials(t *testing.T) {
+	expected := &SecurityInfo{AccessKey: "123", SecretKey: "abc"}
+	cloudianClient, testServer := mockBy(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(expected)
+	})
+	defer testServer.Close()
 
-func randomString(length int) string {
-	var sb strings.Builder
-	runes := []rune(charset)
-	for i := 0; i < length; i++ {
-		sb.WriteRune(runes[rand.Intn(len(runes))])
+	credentials, err := cloudianClient.GetUserCredentials(context.TODO(), "123")
+
+	if err != nil {
+		t.Errorf("Error getting credentials: %v", err)
 	}
-	return sb.String()
+
+	if diff := cmp.Diff(expected, credentials); diff != "" {
+		t.Errorf("GetUserCredentials() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestListUsers(t *testing.T) {
+	expected := []User{{GroupID: "QA", UserID: "user1"}}
+	cloudianClient, testServer := mockBy(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(expected)
+	})
+	defer testServer.Close()
+
+	users, err := cloudianClient.ListUsers(context.TODO(), "QA", nil)
+
+	if err != nil {
+		t.Errorf("Error listing users: %v", err)
+	}
+
+	if diff := cmp.Diff(expected, users); diff != "" {
+		t.Errorf("ListUsers() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func mockBy(handler http.HandlerFunc) (*Client, *httptest.Server) {
+	mockServer := httptest.NewServer(handler)
+
+	return NewClient(mockServer.URL, ""), mockServer
 }


### PR DESCRIPTION
I have a good impression of resty and it's DSL.

Added tests for the endpoints that returns non-empty JSON.
(I can add tests for the others as well, but due to mocking I feel like these don't add too much value at the moment).
Also removed json roundtrip-tests which is now handled by resty.