### PR TITLE
chore!: set Cloudian Group and User ids from Crossplane external-name

### DIFF
--- a/apis/user/v1alpha1/group_types.go
+++ b/apis/user/v1alpha1/group_types.go
@@ -31,11 +31,6 @@ type GroupParameters struct {
 	//+optional
 	//+kubebuilder:default=true
 	Active bool `json:"active"`
-	// GroupID is the group ID (known as Name in the GUI).
-	//+kubebuilder:validation:MinLength=1
-	//+kubebuilder:validation:MaxLength=64
-	//+kubebuilder:validation:Pattern=`^[A-Za-z0-9_-]*$`
-	GroupID string `json:"groupId"`
 	// GroupName is the group name (known as Description in the GUI).
 	//+optional
 	//+kubebuilder:validation:MinLength=1

--- a/apis/user/v1alpha1/user_types.go
+++ b/apis/user/v1alpha1/user_types.go
@@ -28,7 +28,6 @@ import (
 // UserParameters are the configurable fields of a User.
 type UserParameters struct {
 	GroupID string `json:"groupId"`
-	UserID  string `json:"userId"`
 }
 
 // UserObservation are the observable fields of a User.

--- a/package/crds/user.cloudian.crossplane.io_groups.yaml
+++ b/package/crds/user.cloudian.crossplane.io_groups.yaml
@@ -78,12 +78,6 @@ spec:
                     description: Active determines whether the group is enabled (true)
                       or disabled (false) in the system.
                     type: boolean
-                  groupId:
-                    description: GroupID is the group ID (known as Name in the GUI).
-                    maxLength: 64
-                    minLength: 1
-                    pattern: ^[A-Za-z0-9_-]*$
-                    type: string
                   groupName:
                     description: GroupName is the group name (known as Description
                       in the GUI).
@@ -117,8 +111,6 @@ spec:
                       group will be authenticated against the LDAP system when they
                       log into the CMC.
                     type: string
-                required:
-                - groupId
                 type: object
               managementPolicies:
                 default:

--- a/package/crds/user.cloudian.crossplane.io_users.yaml
+++ b/package/crds/user.cloudian.crossplane.io_users.yaml
@@ -75,11 +75,8 @@ spec:
                 properties:
                   groupId:
                     type: string
-                  userId:
-                    type: string
                 required:
                 - groupId
-                - userId
                 type: object
               managementPolicies:
                 default:


### PR DESCRIPTION
Cloudian GroupId seems like an "external name" to me, and using the Crossplane external-name ensures that we don't get any confusion in the mapping between Crossplane and Cloudian.