### PR TITLE
chore(renovate): remove duplicated config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
Removes duplicated Renovate config. The config removed in this PR is the default Renovate config that does not contain our custom settings.

This will enable our regex-markers, automerge and go mod tidy, among other things.

The config that will be effective after this PR is https://github.com/statnett/provider-cloudian/blob/main/.github/renovate.json5