### PR TITLE
chore: remove non-effective MinLength groupName validation

### DIFF
--- a/apis/user/v1alpha1/group_types.go
+++ b/apis/user/v1alpha1/group_types.go
@@ -33,7 +33,6 @@ type GroupParameters struct {
 	Active bool `json:"active"`
 	// GroupName is the group name (known as Description in the GUI).
 	//+optional
-	//+kubebuilder:validation:MinLength=1
 	//+kubebuilder:validation:MaxLength=64
 	GroupName string `json:"groupName,omitempty"`
 	// LDAPEnabled determines whether LDAP authentication is enabled for members of this group.

--- a/package/crds/user.cloudian.crossplane.io_groups.yaml
+++ b/package/crds/user.cloudian.crossplane.io_groups.yaml
@@ -82,7 +82,6 @@ spec:
                     description: GroupName is the group name (known as Description
                       in the GUI).
                     maxLength: 64
-                    minLength: 1
                     type: string
                   ldapEnabled:
                     default: false


### PR DESCRIPTION
Since we have `omitEmpty` (optional field), the validation does not add anything.