### PR TITLE
feat: block user delete untill access keys deleted

### DIFF
--- a/internal/controller/user/user.go
+++ b/internal/controller/user/user.go
@@ -244,6 +244,15 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 		GroupID: cr.Spec.ForProvider.GroupID,
 		UserID:  meta.GetExternalName(mg),
 	}
+
+	creds, err := c.cloudianService.ListUserCredentials(ctx, user)
+	if err != nil {
+		return managed.ExternalDelete{}, err
+	}
+	if len(creds) > 0 {
+		return managed.ExternalDelete{}, errors.New("User has access keys and cannot be deleted")
+	}
+
 	if err := c.cloudianService.DeleteUser(ctx, user); err != nil {
 		return managed.ExternalDelete{}, errors.Wrap(err, errDeleteUser)
 	}


### PR DESCRIPTION
Blocked by https://github.com/statnett/provider-cloudian/pull/146

Built-in support for halting deletion of a User until all its AccessKeys are deleted. Ensures no AccessKey resources are left dangling on finalizers after the User they belong to is deleted.

Replaces the following:

```yaml
              apiVersion: apiextensions.crossplane.io/v1beta1
              kind: Usage
              spec:
                replayDeletion: true
                of:
                  apiVersion: user.cloudian.crossplane.io/v1alpha1
                  kind: User
                by:
                  apiVersion: user.cloudian.crossplane.io/v1alpha1
                  kind: AccessKey
```

If using an AccessKey in a ProviderConfig, and the following Usage, all MRs within a User will now then be deleted before the User is deleted (ProviderConfig awaits deletion of MRs, AccessKey awaits deletion of ProviderConfig, User awaits deletion of AccessKey).

```yaml
              apiVersion: apiextensions.crossplane.io/v1beta1
              kind: Usage
              spec:
                replayDeletion: true
                of:
                  apiVersion: user.cloudian.crossplane.io/v1alpha1
                  kind: AccessKey
                by:
                  apiVersion: aws.upbound.io/v1beta1
                  kind: ProviderConfig
```