### PR TITLE
ci: fix linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ run:
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   formats:
-  - format: colored-line-number
+    - format: colored-line-number
 
 linters-settings:
   errcheck:
@@ -19,15 +19,11 @@ linters-settings:
     # [deprecated] comma-separated list of pairs of the form pkg:regex
     # the regex is used to ignore names within pkg. (default "fmt:.*").
     # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    exclude-functions: fmt:.*,io/ioutil:^Read.*
+    exclude-functions:
+      - "fmt:.*"
+      - "io/ioutil:^Read.*"
 
-  govet:
-    # report about shadowed variables
-    check-shadowing: false
-
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
+  govet: {}
 
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
@@ -41,10 +37,6 @@ linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 10
-
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
 
   dupl:
     # tokens count to trigger issue, 150 by default
@@ -65,7 +57,7 @@ linters-settings:
     # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
     # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
     # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
+    exported-fields-are-used: false
 
   unparam:
     # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
@@ -105,7 +97,7 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - gofmt  # We enable this as well as goimports for its simplify mode.
+    - gofmt # We enable this as well as goimports for its simplify mode.
     - goimports
     - gosimple
     - govet
@@ -120,7 +112,6 @@ linters:
     - bugs
     - unused
   fast: false
-
 
 issues:
   exclude-files:
@@ -137,7 +128,7 @@ issues:
         - gosec
         - exportloopref
         - unparam
-    
+
     # Ease some gocritic warnings on test files.
     - path: _test\.go
       text: "(unnamedResult|exitAfterDefer)"
@@ -149,31 +140,31 @@ issues:
     # rather than using a pointer.
     - text: "(hugeParam|rangeValCopy):"
       linters:
-      - gocritic
+        - gocritic
 
     # This "TestMain should call os.Exit to set exit code" warning is not clever
     # enough to notice that we call a helper method that calls os.Exit.
     - text: "SA3000:"
       linters:
-      - staticcheck
+        - staticcheck
 
     - text: "k8s.io/api/core/v1"
       linters:
-      - goimports
+        - goimports
 
     # This is a "potential hardcoded credentials" warning. It's triggered by
     # any variable with 'secret' in the same, and thus hits a lot of false
     # positives in Kubernetes land where a Secret is an object type.
     - text: "G101:"
       linters:
-      - gosec
-      - gas
+        - gosec
+        - gas
 
     # This is an 'errors unhandled' warning that duplicates errcheck.
     - text: "G104:"
       linters:
-      - gosec
-      - gas
+        - gosec
+        - gas
 
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all
@@ -190,7 +181,7 @@ issues:
   new: false
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-per-linter: 0
+  max-issues-per-linter: 0
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0


### PR DESCRIPTION
See schema https://golangci-lint.run/jsonschema/golangci.jsonschema.json and changelog https://golangci-lint.run/product/changelog/#changelog

`golint` and `maligned` seems deprecated

Might not be 100% equal, but works