### PR TITLE
chore!: rename access key id

### DIFF
--- a/apis/user/v1alpha1/accesskey_types.go
+++ b/apis/user/v1alpha1/accesskey_types.go
@@ -49,8 +49,8 @@ type AccessKeyParameters struct {
 
 // AccessKeyObservation are the observable fields of a AccessKey.
 type AccessKeyObservation struct {
-	// AccessKey is the S3 Access Key ID, with a corresponding SecretKey.
-	AccessKey string `json:"accessKey,omitempty"`
+	// ID is the S3 Access Key ID, with a corresponding SecretKey.
+	ID string `json:"id,omitempty"`
 }
 
 // A AccessKeySpec defines the desired state of a AccessKey.

--- a/internal/controller/accesskey/accesskey.go
+++ b/internal/controller/accesskey/accesskey.go
@@ -158,7 +158,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetCreds)
 	}
 
-	cr.Status.AtProvider.AccessKey = meta.GetExternalName(cr)
+	cr.Status.AtProvider.ID = meta.GetExternalName(cr)
 	cr.SetConditions(xpv1.Available())
 
 	return managed.ExternalObservation{

--- a/package/crds/user.cloudian.crossplane.io_accesskeys.yaml
+++ b/package/crds/user.cloudian.crossplane.io_accesskeys.yaml
@@ -330,8 +330,8 @@ spec:
               atProvider:
                 description: AccessKeyObservation are the observable fields of a AccessKey.
                 properties:
-                  accessKey:
-                    description: AccessKey is the S3 Access Key ID, with a corresponding
+                  id:
+                    description: ID is the S3 Access Key ID, with a corresponding
                       SecretKey.
                     type: string
                 type: object


### PR DESCRIPTION
I think this should either be renamed or removed. Suitable names are `id` or the prefixed version `accessKeyId`. Just `accessKey` on an `AccessKey` is not that informative.

Note: the same value is present in _external-name_ annotation.

https://github.com/crossplane-contrib/provider-aws/blob/master/pkg/controller/iam/accesskey/controller.go

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html