### PR TITLE
chore: bump Go requirement to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/statnett/provider-cloudian
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
Ref. https://github.com/statnett/provider-cloudian/pull/176, we need to bump. It seems like Renovate cannot do this.