### PR TITLE
refactor: remove `init()` functions and `SchemeBuidler` usage

### DIFF
--- a/apis/cluster/cloudian.go
+++ b/apis/cluster/cloudian.go
@@ -24,18 +24,12 @@ import (
 	cloudianv1alpha1 "github.com/statnett/provider-cloudian/apis/cluster/v1alpha1"
 )
 
-func init() {
-	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes,
-		cloudianv1alpha1.SchemeBuilder.AddToScheme,
-		userv1alpha1.SchemeBuilder.AddToScheme,
-	)
-}
-
-// AddToSchemes may be used to add all resources defined in the project to a Scheme
-var AddToSchemes runtime.SchemeBuilder
-
 // AddToScheme adds all Resources to the Scheme
 func AddToScheme(s *runtime.Scheme) error {
-	return AddToSchemes.AddToScheme(s)
+	var schemeCallbacks runtime.SchemeBuilder = []func(*runtime.Scheme) error{
+		cloudianv1alpha1.SchemeBuilder.AddToScheme,
+		userv1alpha1.SchemeBuilder.AddToScheme,
+	}
+
+	return schemeCallbacks.AddToScheme(s)
 }

--- a/apis/cluster/cloudian.go
+++ b/apis/cluster/cloudian.go
@@ -26,10 +26,11 @@ import (
 
 // AddToScheme adds all Resources to the Scheme
 func AddToScheme(s *runtime.Scheme) error {
-	var schemeCallbacks runtime.SchemeBuilder = []func(*runtime.Scheme) error{
-		cloudianv1alpha1.SchemeBuilder.AddToScheme,
-		userv1alpha1.SchemeBuilder.AddToScheme,
+	if err := cloudianv1alpha1.AddKnownTypes(s); err != nil {
+		return err
 	}
-
-	return schemeCallbacks.AddToScheme(s)
+	if err := userv1alpha1.AddKnownTypes(s); err != nil {
+		return err
+	}
+	return nil
 }

--- a/apis/cluster/user/v1alpha1/groupversion_info.go
+++ b/apis/cluster/user/v1alpha1/groupversion_info.go
@@ -35,12 +35,9 @@ const (
 var (
 	// SchemeGroupVersion is group version used to register these objects
 	SchemeGroupVersion = schema.GroupVersion{Group: MetadataGroup, Version: Version}
-
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 )
 
-func addKnownTypes(scheme *runtime.Scheme) error {
+func AddKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&AccessKey{}, &AccessKeyList{},
 		&Group{}, &GroupList{},

--- a/apis/cluster/v1alpha1/groupversion_info.go
+++ b/apis/cluster/v1alpha1/groupversion_info.go
@@ -35,12 +35,9 @@ const (
 var (
 	// SchemeGroupVersion is group version used to register these objects
 	SchemeGroupVersion = schema.GroupVersion{Group: Group, Version: Version}
-
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 )
 
-func addKnownTypes(scheme *runtime.Scheme) error {
+func AddKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&ProviderConfig{}, &ProviderConfigList{},
 		&ProviderConfigUsage{}, &ProviderConfigUsageList{},

--- a/apis/namespaced/cloudian.go
+++ b/apis/namespaced/cloudian.go
@@ -24,18 +24,12 @@ import (
 	cloudianv1alpha1 "github.com/statnett/provider-cloudian/apis/namespaced/v1alpha1"
 )
 
-func init() {
-	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes,
-		cloudianv1alpha1.SchemeBuilder.AddToScheme,
-		userv1alpha1.SchemeBuilder.AddToScheme,
-	)
-}
-
-// AddToSchemes may be used to add all resources defined in the project to a Scheme
-var AddToSchemes runtime.SchemeBuilder
-
 // AddToScheme adds all Resources to the Scheme
 func AddToScheme(s *runtime.Scheme) error {
-	return AddToSchemes.AddToScheme(s)
+	var schemeCallbacks runtime.SchemeBuilder = []func(*runtime.Scheme) error{
+		cloudianv1alpha1.SchemeBuilder.AddToScheme,
+		userv1alpha1.SchemeBuilder.AddToScheme,
+	}
+
+	return schemeCallbacks.AddToScheme(s)
 }

--- a/apis/namespaced/cloudian.go
+++ b/apis/namespaced/cloudian.go
@@ -26,10 +26,11 @@ import (
 
 // AddToScheme adds all Resources to the Scheme
 func AddToScheme(s *runtime.Scheme) error {
-	var schemeCallbacks runtime.SchemeBuilder = []func(*runtime.Scheme) error{
-		cloudianv1alpha1.SchemeBuilder.AddToScheme,
-		userv1alpha1.SchemeBuilder.AddToScheme,
+	if err := cloudianv1alpha1.AddKnownTypes(s); err != nil {
+		return err
 	}
-
-	return schemeCallbacks.AddToScheme(s)
+	if err := userv1alpha1.AddKnownTypes(s); err != nil {
+		return err
+	}
+	return nil
 }

--- a/apis/namespaced/user/v1alpha1/groupversion_info.go
+++ b/apis/namespaced/user/v1alpha1/groupversion_info.go
@@ -35,12 +35,9 @@ const (
 var (
 	// SchemeGroupVersion is group version used to register these objects
 	SchemeGroupVersion = schema.GroupVersion{Group: MetadataGroup, Version: Version}
-
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 )
 
-func addKnownTypes(scheme *runtime.Scheme) error {
+func AddKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&AccessKey{}, &AccessKeyList{},
 		&Group{}, &GroupList{},

--- a/apis/namespaced/v1alpha1/groupversion_info.go
+++ b/apis/namespaced/v1alpha1/groupversion_info.go
@@ -35,12 +35,9 @@ const (
 var (
 	// SchemeGroupVersion is group version used to register these objects
 	SchemeGroupVersion = schema.GroupVersion{Group: Group, Version: Version}
-
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 )
 
-func addKnownTypes(scheme *runtime.Scheme) error {
+func AddKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&ProviderConfig{}, &ProviderConfigList{},
 		&ClusterProviderConfig{}, &ClusterProviderConfigList{},


### PR DESCRIPTION
I don't think we were adding things twice. I do however think it's more direct and readable to do it this way. It avoids `init()` as well as the `SchemeBuilder` which, as far as I can tell, was just a convenience wrapper. Please correct me if I'm hallucinating.