### PR TITLE
refactor: get rid of remaining init functions

### DIFF
--- a/apis/cluster/cloudian.go
+++ b/apis/cluster/cloudian.go
@@ -24,18 +24,20 @@ import (
 	cloudianv1alpha1 "github.com/statnett/provider-cloudian/apis/cluster/v1alpha1"
 )
 
-func init() {
-	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes,
-		cloudianv1alpha1.SchemeBuilder.AddToScheme,
-		userv1alpha1.SchemeBuilder.AddToScheme,
-	)
-}
+var (
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
-// AddToSchemes may be used to add all resources defined in the project to a Scheme
-var AddToSchemes runtime.SchemeBuilder
+	// AddToScheme may be used to add all cluster-scoped resources defined in the project to a Scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)
 
-// AddToScheme adds all Resources to the Scheme
-func AddToScheme(s *runtime.Scheme) error {
-	return AddToSchemes.AddToScheme(s)
+func addKnownTypes(scheme *runtime.Scheme) error {
+	for _, sb := range []runtime.SchemeBuilder{cloudianv1alpha1.SchemeBuilder, userv1alpha1.SchemeBuilder} {
+		if err := sb.AddToScheme(scheme); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/apis/namespaced/cloudian.go
+++ b/apis/namespaced/cloudian.go
@@ -24,18 +24,20 @@ import (
 	cloudianv1alpha1 "github.com/statnett/provider-cloudian/apis/namespaced/v1alpha1"
 )
 
-func init() {
-	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes,
-		cloudianv1alpha1.SchemeBuilder.AddToScheme,
-		userv1alpha1.SchemeBuilder.AddToScheme,
-	)
-}
+var (
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
-// AddToSchemes may be used to add all resources defined in the project to a Scheme
-var AddToSchemes runtime.SchemeBuilder
+	// AddToScheme may be used to add all namespace-scoped resources defined in the project to a Scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)
 
-// AddToScheme adds all Resources to the Scheme
-func AddToScheme(s *runtime.Scheme) error {
-	return AddToSchemes.AddToScheme(s)
+func addKnownTypes(scheme *runtime.Scheme) error {
+	for _, sb := range []runtime.SchemeBuilder{cloudianv1alpha1.SchemeBuilder, userv1alpha1.SchemeBuilder} {
+		if err := sb.AddToScheme(scheme); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR drops the remaining init-functions by aligning the top-level schemes with the package schemes. We could alternatively drop this indirection completely and load schemes directly per package in main.go. Ref: 

https://github.com/statnett/provider-cloudian/blob/365f6606b5ca59b84b9835f433d7bb298a423d43/cmd/provider/main.go#L105

Right now, we don't load the namespaced resource schemes, which should be fixed in a follow-up PR.