### PR TITLE
feat: add namespaced controllers

### DIFF
--- a/internal/controller/namespaced/accesskey/accesskey.go
+++ b/internal/controller/namespaced/accesskey/accesskey.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accesskey
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+
+	userv1alpha1namespaced "github.com/statnett/provider-cloudian/apis/namespaced/user/v1alpha1"
+	apisv1alpha1namespaced "github.com/statnett/provider-cloudian/apis/namespaced/v1alpha1"
+	controllercommon "github.com/statnett/provider-cloudian/internal/controller/common"
+	accesskeycontrollercommon "github.com/statnett/provider-cloudian/internal/controller/common/accesskey"
+	"github.com/statnett/provider-cloudian/internal/sdk/cloudian"
+)
+
+const (
+	errNotAccessKey = "managed resource is not a AccessKey custom resource"
+	errTrackPCUsage = "cannot track ProviderConfig usage"
+	errGetPC        = "cannot get ProviderConfig"
+	errCreateCreds  = "cannot create credentials"
+	errGetCreds     = "cannot get credentials"
+	errDeleteCreds  = "cannot delete credentials"
+
+	errNewClient = "cannot create new Service"
+)
+
+// Setup adds a controller that reconciles AccessKey managed resources.
+func Setup(mgr ctrl.Manager, o controller.Options) error {
+	name := managed.ControllerName(userv1alpha1namespaced.AccessKeyGroupKind)
+
+	r := managed.NewReconciler(mgr,
+		resource.ManagedKind(userv1alpha1namespaced.AccessKeyGroupVersionKind),
+		managed.WithExternalConnector(&connector{
+			kube:         mgr.GetClient(),
+			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1namespaced.ProviderConfigUsage{}),
+			newServiceFn: controllercommon.NewCloudianService}),
+		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithPollInterval(o.PollInterval),
+		//nolint:staticcheck // SA1004 crossplane-runtime still depends on deprecated API
+		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		WithOptions(o.ForControllerRuntime()).
+		WithEventFilter(resource.DesiredStateChanged()).
+		For(&userv1alpha1namespaced.AccessKey{}).
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+}
+
+// A connector is expected to produce an ExternalClient when its Connect method
+// is called.
+type connector struct {
+	kube         client.Client
+	usage        *resource.ProviderConfigUsageTracker
+	newServiceFn func(providerConfigEndpoitn string, authHeader string) (*cloudian.Client, error)
+}
+
+// Connect typically produces an ExternalClient by:
+// 1. Tracking that the managed resource is using a ProviderConfig.
+// 2. Getting the managed resource's ProviderConfig.
+// 3. Getting the credentials specified by the ProviderConfig.
+// 4. Using the credentials to form a client.
+func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.AccessKey)
+	if !ok {
+		return nil, errors.New(errNotAccessKey)
+	}
+
+	if err := c.usage.Track(ctx, cr); err != nil {
+		return nil, errors.Wrap(err, errTrackPCUsage)
+	}
+
+	pc := &apisv1alpha1namespaced.ProviderConfig{}
+	if err := c.kube.Get(ctx, types.NamespacedName{Name: cr.GetProviderConfigReference().Name}, pc); err != nil {
+		return nil, errors.Wrap(err, errGetPC)
+	}
+
+	cd := pc.Spec.AuthHeader
+	authHeader, err := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+	if err != nil {
+		return nil, errors.Wrap(err, errGetCreds)
+	}
+
+	svc, err := c.newServiceFn(pc.Spec.Endpoint, string(authHeader))
+	if err != nil {
+		return nil, errors.Wrap(err, errNewClient)
+	}
+
+	return &external{cloudianService: svc}, nil
+}
+
+// An ExternalClient observes, then either creates, updates, or deletes an
+// external resource to ensure it reflects the managed resource's desired state.
+type external struct {
+	// A 'client' used to connect to the external resource API. In practice this
+	// would be something like an AWS SDK client.
+	cloudianService *cloudian.Client
+}
+
+func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.AccessKey)
+	if !ok {
+		return managed.ExternalObservation{}, errors.New(errNotAccessKey)
+	}
+
+	if meta.GetExternalName(cr) == "" {
+		return managed.ExternalObservation{ResourceExists: false}, nil
+	}
+
+	creds, err := c.cloudianService.GetUserCredentials(ctx, meta.GetExternalName(cr))
+	if errors.Is(err, cloudian.ErrNotFound) {
+		return managed.ExternalObservation{ResourceExists: false}, nil
+	}
+	if err != nil {
+		return managed.ExternalObservation{}, errors.Wrap(err, errGetCreds)
+	}
+
+	cr.Status.AtProvider.ID = meta.GetExternalName(cr)
+	cr.SetConditions(xpv2.Available())
+
+	return managed.ExternalObservation{
+		// Return false when the external resource does not exist. This lets
+		// the managed resource reconciler know that it needs to call Create to
+		// (re)create the resource, or that it has successfully been deleted.
+		ResourceExists: true,
+
+		// Return false when the external resource exists, but it not up to date
+		// with the desired managed resource state. This lets the managed
+		// resource reconciler know that it needs to call Update.
+		// TODO: Check Inactivate / Activate
+		ResourceUpToDate: true,
+
+		// Return any details that may be required to connect to the external
+		// resource. These will be stored as the connection secret.
+		ConnectionDetails: accesskeycontrollercommon.ConnectionDetails(creds),
+	}, nil
+}
+
+func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.AccessKey)
+	if !ok {
+		return managed.ExternalCreation{}, errors.New(errNotAccessKey)
+	}
+
+	cr.SetConditions(xpv2.Creating())
+
+	creds, err := c.cloudianService.CreateUserCredentials(ctx, cloudian.GroupUserID{
+		GroupID: cr.Spec.ForProvider.GroupID,
+		UserID:  cr.Spec.ForProvider.UserID,
+	})
+	if err != nil {
+		return managed.ExternalCreation{}, errors.Wrap(err, errCreateCreds)
+	}
+
+	meta.SetExternalName(cr, creds.AccessKey)
+
+	return managed.ExternalCreation{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: accesskeycontrollercommon.ConnectionDetails(creds),
+	}, nil
+}
+
+func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+	_, ok := mg.(*userv1alpha1namespaced.AccessKey)
+	if !ok {
+		return managed.ExternalUpdate{}, errors.New(errNotAccessKey)
+	}
+
+	// TODO: Update Inactivate / Activate
+
+	return managed.ExternalUpdate{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.AccessKey)
+	if !ok {
+		return managed.ExternalDelete{}, errors.New(errNotAccessKey)
+	}
+
+	cr.SetConditions(xpv2.Deleting())
+
+	err := c.cloudianService.DeleteUserCredentials(ctx, meta.GetExternalName(cr))
+	if err != nil && !errors.Is(err, cloudian.ErrNotFound) {
+		return managed.ExternalDelete{}, errors.Wrap(err, errGetCreds)
+	}
+
+	return managed.ExternalDelete{}, nil
+}
+
+func (c *external) Disconnect(ctx context.Context) error {
+	return nil
+}

--- a/internal/controller/namespaced/accesskey/accesskey_test.go
+++ b/internal/controller/namespaced/accesskey/accesskey_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accesskey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+)
+
+// Unlike many Kubernetes projects Crossplane does not use third party testing
+// libraries, per the common Go test review comments. Crossplane encourages the
+// use of table driven unit tests. The tests of the crossplane-runtime project
+// are representative of the testing style Crossplane encourages.
+//
+// https://github.com/golang/go/wiki/TestComments
+// https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#contributing-code
+
+func TestObserve(t *testing.T) {
+	type fields struct {
+	}
+
+	type args struct {
+		ctx context.Context
+		mg  resource.Managed
+	}
+
+	type want struct {
+		o   managed.ExternalObservation
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		fields fields
+		args   args
+		want   want
+	}{
+		// TODO: Add test cases.
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := external{}
+			got, err := e.Observe(tc.args.ctx, tc.args.mg)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.o, got); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/controller/namespaced/config/config.go
+++ b/internal/controller/namespaced/config/config.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/providerconfig"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	apisv1alpha1namespaced "github.com/statnett/provider-cloudian/apis/namespaced/v1alpha1"
+)
+
+// Setup adds a controller that reconciles ProviderConfigs by accounting for
+// their current usage.
+func Setup(mgr ctrl.Manager, o controller.Options) error {
+	name := providerconfig.ControllerName(apisv1alpha1namespaced.ProviderConfigGroupKind)
+
+	of := resource.ProviderConfigKinds{
+		Config:    apisv1alpha1namespaced.ProviderConfigGroupVersionKind,
+		Usage:     apisv1alpha1namespaced.ProviderConfigUsageGroupVersionKind,
+		UsageList: apisv1alpha1namespaced.ProviderConfigUsageListGroupVersionKind,
+	}
+
+	r := providerconfig.NewReconciler(mgr, of,
+		providerconfig.WithLogger(o.Logger.WithValues("controller", name)),
+		//nolint:staticcheck // SA1004 crossplane-runtime still depends on deprecated API
+		providerconfig.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		WithOptions(o.ForControllerRuntime()).
+		For(&apisv1alpha1namespaced.ProviderConfig{}).
+		Watches(&apisv1alpha1namespaced.ProviderConfigUsage{}, &resource.EnqueueRequestForProviderConfig{}).
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+}

--- a/internal/controller/namespaced/group/group.go
+++ b/internal/controller/namespaced/group/group.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+
+	userv1alpha1namespaced "github.com/statnett/provider-cloudian/apis/namespaced/user/v1alpha1"
+	apisv1alpha1namespaced "github.com/statnett/provider-cloudian/apis/namespaced/v1alpha1"
+	controllercommon "github.com/statnett/provider-cloudian/internal/controller/common"
+	groupcontrollercommon "github.com/statnett/provider-cloudian/internal/controller/common/group"
+	"github.com/statnett/provider-cloudian/internal/sdk/cloudian"
+)
+
+const (
+	errNotGroup     = "managed resource is not a Group custom resource"
+	errTrackPCUsage = "cannot track ProviderConfig usage"
+	errGetPC        = "cannot get ProviderConfig"
+	errGetCreds     = "cannot get credentials"
+
+	errNewClient   = "cannot create new Service"
+	errCreateGroup = "cannot create Group"
+	errDeleteGroup = "cannot delete Group"
+	errGetGroup    = "cannot get Group"
+	errUpdateGroup = "cannot update Group"
+)
+
+// Setup adds a controller that reconciles Group managed resources.
+func Setup(mgr ctrl.Manager, o controller.Options) error {
+	name := managed.ControllerName(userv1alpha1namespaced.GroupGroupKind)
+
+	r := managed.NewReconciler(mgr,
+		resource.ManagedKind(userv1alpha1namespaced.GroupGroupVersionKind),
+		managed.WithExternalConnector(&connector{
+			kube:         mgr.GetClient(),
+			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1namespaced.ProviderConfigUsage{}),
+			newServiceFn: controllercommon.NewCloudianService}),
+		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithPollInterval(o.PollInterval),
+		//nolint:staticcheck // SA1004 crossplane-runtime still depends on deprecated API
+		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		WithOptions(o.ForControllerRuntime()).
+		WithEventFilter(resource.DesiredStateChanged()).
+		For(&userv1alpha1namespaced.Group{}).
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+}
+
+// A connector is expected to produce an ExternalClient when its Connect method
+// is called.
+type connector struct {
+	kube         client.Client
+	usage        *resource.ProviderConfigUsageTracker
+	newServiceFn func(providerConfigEndpoint string, authHeader string) (*cloudian.Client, error)
+}
+
+// Connect typically produces an ExternalClient by:
+// 1. Tracking that the managed resource is using a ProviderConfig.
+// 2. Getting the managed resource's ProviderConfig.
+// 3. Getting the credentials specified by the ProviderConfig.
+// 4. Using the credentials to form a client.
+func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.Group)
+	if !ok {
+		return nil, errors.New(errNotGroup)
+	}
+
+	if err := c.usage.Track(ctx, cr); err != nil {
+		return nil, errors.Wrap(err, errTrackPCUsage)
+	}
+
+	pc := &apisv1alpha1namespaced.ProviderConfig{}
+	if err := c.kube.Get(ctx, types.NamespacedName{Name: cr.GetProviderConfigReference().Name}, pc); err != nil {
+		return nil, errors.Wrap(err, errGetPC)
+	}
+
+	cd := pc.Spec.AuthHeader
+	authHeader, err := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+	if err != nil {
+		return nil, errors.Wrap(err, errGetCreds)
+	}
+
+	svc, err := c.newServiceFn(pc.Spec.Endpoint, string(authHeader))
+	if err != nil {
+		return nil, errors.Wrap(err, errNewClient)
+	}
+
+	return &external{cloudianService: svc}, nil
+}
+
+// An ExternalClient observes, then either creates, updates, or deletes an
+// external resource to ensure it reflects the managed resource's desired state.
+type external struct {
+	// A 'client' used to connect to the external resource API. In practice this
+	// would be something like an AWS SDK client.
+	cloudianService *cloudian.Client
+}
+
+func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.Group)
+	if !ok {
+		return managed.ExternalObservation{}, errors.New(errNotGroup)
+	}
+
+	externalName := meta.GetExternalName(cr)
+	if externalName == "" {
+		return managed.ExternalObservation{}, nil
+	}
+
+	observedGroup, err := c.cloudianService.GetGroup(ctx, externalName)
+	if errors.Is(err, cloudian.ErrNotFound) {
+		return managed.ExternalObservation{ResourceExists: false}, nil
+	}
+	if err != nil {
+		return managed.ExternalObservation{}, errors.Wrap(err, errGetGroup)
+	}
+
+	cr.SetConditions(xpv2.Available())
+
+	return managed.ExternalObservation{
+		// Return false when the external resource does not exist. This lets
+		// the managed resource reconciler know that it needs to call Create to
+		// (re)create the resource, or that it has successfully been deleted.
+		ResourceExists: true,
+
+		// Return false when the external resource exists, but it not up to date
+		// with the desired managed resource state. This lets the managed
+		// resource reconciler know that it needs to call Update.
+		ResourceUpToDate: groupcontrollercommon.IsUpToDate(meta.GetExternalName(mg), cr.Spec.ForProvider, *observedGroup),
+
+		// Return any details that may be required to connect to the external
+		// resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.Group)
+	if !ok {
+		return managed.ExternalCreation{}, errors.New(errNotGroup)
+	}
+
+	cr.SetConditions(xpv2.Creating())
+
+	if err := c.cloudianService.CreateGroup(ctx, groupcontrollercommon.NewCloudianGroup(meta.GetExternalName(mg), cr.Spec.ForProvider)); err != nil {
+		return managed.ExternalCreation{}, errors.Wrap(err, errCreateGroup)
+	}
+
+	return managed.ExternalCreation{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.Group)
+	if !ok {
+		return managed.ExternalUpdate{}, errors.New(errNotGroup)
+	}
+
+	if err := c.cloudianService.UpdateGroup(ctx, groupcontrollercommon.NewCloudianGroup(meta.GetExternalName(mg), cr.Spec.ForProvider)); err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateGroup)
+	}
+
+	return managed.ExternalUpdate{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.Group)
+	if !ok {
+		return managed.ExternalDelete{}, errors.New(errNotGroup)
+	}
+
+	cr.SetConditions(xpv2.Deleting())
+
+	if err := c.cloudianService.DeleteGroup(ctx, meta.GetExternalName(mg)); err != nil {
+		return managed.ExternalDelete{}, errors.Wrap(err, errDeleteGroup)
+	}
+
+	return managed.ExternalDelete{}, nil
+}
+
+func (c *external) Disconnect(ctx context.Context) error {
+	return nil
+}

--- a/internal/controller/namespaced/group/group_test.go
+++ b/internal/controller/namespaced/group/group_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package group
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+)
+
+// Unlike many Kubernetes projects Crossplane does not use third party testing
+// libraries, per the common Go test review comments. Crossplane encourages the
+// use of table driven unit tests. The tests of the crossplane-runtime project
+// are representative of the testing style Crossplane encourages.
+//
+// https://github.com/golang/go/wiki/TestComments
+// https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#contributing-code
+
+func TestObserve(t *testing.T) {
+	type fields struct {
+		_ interface{}
+	}
+
+	type args struct {
+		ctx context.Context
+		mg  resource.Managed
+	}
+
+	type want struct {
+		o   managed.ExternalObservation
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		fields fields
+		args   args
+		want   want
+	}{
+		// TODO: Add test cases.
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := external{cloudianService: nil}
+			got, err := e.Observe(tc.args.ctx, tc.args.mg)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.o, got); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/controller/namespaced/groupqualityofservicelimits/groupqualityofservicelimits.go
+++ b/internal/controller/namespaced/groupqualityofservicelimits/groupqualityofservicelimits.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package groupqualityofservicelimits
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+
+	userv1alpha1namespaced "github.com/statnett/provider-cloudian/apis/namespaced/user/v1alpha1"
+	apisv1alpha1namespaced "github.com/statnett/provider-cloudian/apis/namespaced/v1alpha1"
+	controllercommon "github.com/statnett/provider-cloudian/internal/controller/common"
+	qoslimitscommon "github.com/statnett/provider-cloudian/internal/controller/common/qualityofservicelimits"
+	"github.com/statnett/provider-cloudian/internal/sdk/cloudian"
+)
+
+const (
+	errNotGroupQualityOfServiceLimits = "managed resource is not a GroupQualityOfServiceLimits custom resource"
+	errTrackPCUsage                   = "cannot track ProviderConfig usage"
+	errGetPC                          = "cannot get ProviderConfig"
+	errGetCreds                       = "cannot get credentials"
+
+	errNewClient = "cannot create new Service"
+	errCreateQOS = "cannot create QOS"
+	errDeleteQOS = "cannot delete QOS"
+	errGetQOS    = "cannot get QOS"
+)
+
+// Setup adds a controller that reconciles GroupQualityOfServiceLimits managed resources.
+func Setup(mgr ctrl.Manager, o controller.Options) error {
+	name := managed.ControllerName(userv1alpha1namespaced.GroupQualityOfServiceLimitsGroupKind)
+
+	r := managed.NewReconciler(mgr,
+		resource.ManagedKind(userv1alpha1namespaced.GroupQualityOfServiceLimitsGroupVersionKind),
+		managed.WithExternalConnector(&connector{
+			kube:         mgr.GetClient(),
+			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1namespaced.ProviderConfigUsage{}),
+			newServiceFn: controllercommon.NewCloudianService,
+		}),
+		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithPollInterval(o.PollInterval),
+		//nolint:staticcheck // SA1004 crossplane-runtime still depends on deprecated API
+		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		WithOptions(o.ForControllerRuntime()).
+		WithEventFilter(resource.DesiredStateChanged()).
+		For(&userv1alpha1namespaced.GroupQualityOfServiceLimits{}).
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+}
+
+// A connector is expected to produce an ExternalClient when its Connect method
+// is called.
+type connector struct {
+	kube         client.Client
+	usage        *resource.ProviderConfigUsageTracker
+	newServiceFn func(providerConfigEndpoint string, authHeader string) (*cloudian.Client, error)
+}
+
+// Connect typically produces an ExternalClient by:
+// 1. Tracking that the managed resource is using a ProviderConfig.
+// 2. Getting the managed resource's ProviderConfig.
+// 3. Getting the credentials specified by the ProviderConfig.
+// 4. Using the credentials to form a client.
+func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.GroupQualityOfServiceLimits)
+	if !ok {
+		return nil, errors.New(errNotGroupQualityOfServiceLimits)
+	}
+
+	if err := c.usage.Track(ctx, cr); err != nil {
+		return nil, errors.Wrap(err, errTrackPCUsage)
+	}
+
+	pc := &apisv1alpha1namespaced.ProviderConfig{}
+	if err := c.kube.Get(ctx, types.NamespacedName{Name: cr.GetProviderConfigReference().Name}, pc); err != nil {
+		return nil, errors.Wrap(err, errGetPC)
+	}
+
+	cd := pc.Spec.AuthHeader
+	authHeader, err := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+	if err != nil {
+		return nil, errors.Wrap(err, errGetCreds)
+	}
+
+	svc, err := c.newServiceFn(pc.Spec.Endpoint, string(authHeader))
+	if err != nil {
+		return nil, errors.Wrap(err, errNewClient)
+	}
+
+	return &external{cloudianService: svc}, nil
+}
+
+// An ExternalClient observes, then either creates, updates, or deletes an
+// external resource to ensure it reflects the managed resource's desired state.
+type external struct {
+	// A 'client' used to connect to the external resource API. In practice this
+	// would be something like an AWS SDK client.
+	cloudianService *cloudian.Client
+}
+
+func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.GroupQualityOfServiceLimits)
+	if !ok {
+		return managed.ExternalObservation{}, errors.New(errNotGroupQualityOfServiceLimits)
+	}
+
+	groupID := cr.Spec.ForProvider.GroupID
+	if groupID == "" {
+		return managed.ExternalObservation{}, nil
+	}
+
+	guid := cloudian.GroupUserID{
+		GroupID: groupID,
+		UserID:  "*",
+	}
+	qos, err := c.cloudianService.GetQOS(ctx, guid, cr.Spec.ForProvider.Region)
+
+	if errors.Is(err, cloudian.ErrNotFound) {
+		return managed.ExternalObservation{ResourceExists: false}, nil
+	}
+	if err != nil {
+		return managed.ExternalObservation{}, errors.Wrap(err, errGetQOS)
+	}
+
+	cr.SetConditions(xpv2.Available())
+
+	expected, err := qoslimitscommon.ToCloudianQOS(cr.Spec.ForProvider.QOS)
+	if err != nil {
+		return managed.ExternalObservation{}, err
+	}
+
+	return managed.ExternalObservation{
+		// Return false when the external resource does not exist. This lets
+		// the managed resource reconciler know that it needs to call Create to
+		// (re)create the resource, or that it has successfully been deleted.
+		ResourceExists: true,
+
+		// Return false when the external resource exists, but it not up to date
+		// with the desired managed resource state. This lets the managed
+		// resource reconciler know that it needs to call Update.
+		ResourceUpToDate: expected.Warning.Equal(qos.Warning) &&
+			expected.Hard.Equal(qos.Hard),
+
+		// Return any details that may be required to connect to the external
+		// resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.GroupQualityOfServiceLimits)
+	if !ok {
+		return managed.ExternalCreation{}, errors.New(errNotGroupQualityOfServiceLimits)
+	}
+
+	qos, err := qoslimitscommon.ToCloudianQOS(cr.Spec.ForProvider.QOS)
+	if err != nil {
+		return managed.ExternalCreation{}, err
+	}
+
+	guid := cloudian.GroupUserID{
+		GroupID: cr.Spec.ForProvider.GroupID,
+		UserID:  "*",
+	}
+	if err := c.cloudianService.SetQOS(ctx, guid, cr.Spec.ForProvider.Region, qos); err != nil {
+		return managed.ExternalCreation{}, errors.Wrap(err, errCreateQOS)
+	}
+
+	return managed.ExternalCreation{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.GroupQualityOfServiceLimits)
+	if !ok {
+		return managed.ExternalUpdate{}, errors.New(errNotGroupQualityOfServiceLimits)
+	}
+
+	qos, err := qoslimitscommon.ToCloudianQOS(cr.Spec.ForProvider.QOS)
+	if err != nil {
+		return managed.ExternalUpdate{}, err
+	}
+
+	guid := cloudian.GroupUserID{
+		GroupID: cr.Spec.ForProvider.GroupID,
+		UserID:  "*",
+	}
+	if err := c.cloudianService.SetQOS(ctx, guid, cr.Spec.ForProvider.Region, qos); err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, errCreateQOS)
+	}
+
+	return managed.ExternalUpdate{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.GroupQualityOfServiceLimits)
+	if !ok {
+		return managed.ExternalDelete{}, errors.New(errNotGroupQualityOfServiceLimits)
+	}
+
+	cr.SetConditions(xpv2.Deleting())
+
+	guid := cloudian.GroupUserID{
+		GroupID: cr.Spec.ForProvider.GroupID,
+		UserID:  "*",
+	}
+	err := c.cloudianService.DeleteQOS(ctx, guid, cr.Spec.ForProvider.Region)
+	if err != nil && !errors.Is(err, cloudian.ErrNotFound) {
+		return managed.ExternalDelete{}, errors.Wrap(err, errGetCreds)
+	}
+
+	return managed.ExternalDelete{}, nil
+}
+
+func (c *external) Disconnect(ctx context.Context) error {
+	return nil
+}

--- a/internal/controller/namespaced/groupqualityofservicelimits/groupqualityofservicelimits_test.go
+++ b/internal/controller/namespaced/groupqualityofservicelimits/groupqualityofservicelimits_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package groupqualityofservicelimits
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+)
+
+// Unlike many Kubernetes projects Crossplane does not use third party testing
+// libraries, per the common Go test review comments. Crossplane encourages the
+// use of table driven unit tests. The tests of the crossplane-runtime project
+// are representative of the testing style Crossplane encourages.
+//
+// https://github.com/golang/go/wiki/TestComments
+// https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#contributing-code
+
+func TestObserve(t *testing.T) {
+	type fields struct {
+	}
+
+	type args struct {
+		ctx context.Context
+		mg  resource.Managed
+	}
+
+	type want struct {
+		o   managed.ExternalObservation
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		fields fields
+		args   args
+		want   want
+	}{
+		// TODO: Add test cases.
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := external{}
+			got, err := e.Observe(tc.args.ctx, tc.args.mg)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.o, got); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/controller/namespaced/namespaced.go
+++ b/internal/controller/namespaced/namespaced.go
@@ -14,24 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package namespaced
 
 import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	controllercluster "github.com/statnett/provider-cloudian/internal/controller/cluster"
-	controllernamespaced "github.com/statnett/provider-cloudian/internal/controller/namespaced"
+	"github.com/statnett/provider-cloudian/internal/controller/namespaced/accesskey"
+	"github.com/statnett/provider-cloudian/internal/controller/namespaced/config"
+	"github.com/statnett/provider-cloudian/internal/controller/namespaced/group"
+	"github.com/statnett/provider-cloudian/internal/controller/namespaced/groupqualityofservicelimits"
+	"github.com/statnett/provider-cloudian/internal/controller/namespaced/user"
+	"github.com/statnett/provider-cloudian/internal/controller/namespaced/userqualityofservicelimits"
 )
 
 // Setup creates all Cloudian controllers with the supplied logger and adds them to
 // the supplied manager.
 func Setup(mgr ctrl.Manager, o controller.Options) error {
-	if err := controllercluster.Setup(mgr, o); err != nil {
-		return err
-	}
-	if err := controllernamespaced.Setup(mgr, o); err != nil {
-		return err
+	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+		accesskey.Setup,
+		config.Setup,
+		group.Setup,
+		groupqualityofservicelimits.Setup,
+		user.Setup,
+		userqualityofservicelimits.Setup,
+	} {
+		if err := setup(mgr, o); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/controller/namespaced/user/user.go
+++ b/internal/controller/namespaced/user/user.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package user
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+
+	userv1alpha1namespaced "github.com/statnett/provider-cloudian/apis/namespaced/user/v1alpha1"
+	apisv1alpha1namespaced "github.com/statnett/provider-cloudian/apis/namespaced/v1alpha1"
+	controllercommon "github.com/statnett/provider-cloudian/internal/controller/common"
+	"github.com/statnett/provider-cloudian/internal/sdk/cloudian"
+)
+
+const (
+	errNotUser      = "managed resource is not a User custom resource"
+	errTrackPCUsage = "cannot track ProviderConfig usage"
+	errGetPC        = "cannot get ProviderConfig"
+	errGetCreds     = "cannot get credentials"
+
+	errNewClient  = "cannot create new Service"
+	errCreateUser = "cannot create User"
+	errDeleteUser = "cannot delete User"
+	errGetUser    = "cannot get User"
+)
+
+// Setup adds a controller that reconciles User managed resources.
+func Setup(mgr ctrl.Manager, o controller.Options) error {
+	name := managed.ControllerName(userv1alpha1namespaced.UserGroupKind)
+
+	r := managed.NewReconciler(mgr,
+		resource.ManagedKind(userv1alpha1namespaced.UserGroupVersionKind),
+		managed.WithExternalConnector(&connector{
+			kube:         mgr.GetClient(),
+			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1namespaced.ProviderConfigUsage{}),
+			newServiceFn: controllercommon.NewCloudianService}),
+		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithPollInterval(o.PollInterval),
+		//nolint:staticcheck // SA1004 crossplane-runtime still depends on deprecated API
+		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		WithOptions(o.ForControllerRuntime()).
+		WithEventFilter(resource.DesiredStateChanged()).
+		For(&userv1alpha1namespaced.User{}).
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+}
+
+// A connector is expected to produce an ExternalClient when its Connect method
+// is called.
+type connector struct {
+	kube         client.Client
+	usage        *resource.ProviderConfigUsageTracker
+	newServiceFn func(providerConfigEndpoint string, authHeader string) (*cloudian.Client, error)
+}
+
+// Connect typically produces an ExternalClient by:
+// 1. Tracking that the managed resource is using a ProviderConfig.
+// 2. Getting the managed resource's ProviderConfig.
+// 3. Getting the credentials specified by the ProviderConfig.
+// 4. Using the credentials to form a client.
+func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.User)
+	if !ok {
+		return nil, errors.New(errNotUser)
+	}
+
+	if err := c.usage.Track(ctx, cr); err != nil {
+		return nil, errors.Wrap(err, errTrackPCUsage)
+	}
+
+	pc := &apisv1alpha1namespaced.ProviderConfig{}
+	if err := c.kube.Get(ctx, types.NamespacedName{Name: cr.GetProviderConfigReference().Name}, pc); err != nil {
+		return nil, errors.Wrap(err, errGetPC)
+	}
+
+	cd := pc.Spec.AuthHeader
+	authHeader, err := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+	if err != nil {
+		return nil, errors.Wrap(err, errGetCreds)
+	}
+
+	svc, err := c.newServiceFn(pc.Spec.Endpoint, string(authHeader))
+	if err != nil {
+		return nil, errors.Wrap(err, errNewClient)
+	}
+
+	return &external{cloudianService: svc}, nil
+}
+
+// An ExternalClient observes, then either creates, updates, or deletes an
+// external resource to ensure it reflects the managed resource's desired state.
+type external struct {
+	// A 'client' used to connect to the external resource API. In practice this
+	// would be something like an AWS SDK client.
+	cloudianService *cloudian.Client
+}
+
+func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.User)
+	if !ok {
+		return managed.ExternalObservation{}, errors.New(errNotUser)
+	}
+
+	externalName := meta.GetExternalName(cr)
+	if externalName == "" {
+		return managed.ExternalObservation{}, nil
+	}
+
+	group := cr.Spec.ForProvider.GroupID
+	if group == "" {
+		return managed.ExternalObservation{}, nil
+	}
+
+	user, err := c.cloudianService.GetUser(ctx, cloudian.GroupUserID{
+		GroupID: group,
+		UserID:  externalName})
+	if errors.Is(err, cloudian.ErrNotFound) {
+		return managed.ExternalObservation{ResourceExists: false}, nil
+	}
+	if err != nil {
+		return managed.ExternalObservation{}, errors.Wrap(err, errGetUser)
+	}
+
+	cr.Status.AtProvider.CanonicalID = user.CanonicalID
+	cr.SetConditions(xpv2.Available())
+
+	return managed.ExternalObservation{
+		// Return false when the external resource does not exist. This lets
+		// the managed resource reconciler know that it needs to call Create to
+		// (re)create the resource, or that it has successfully been deleted.
+		ResourceExists: true,
+
+		// Return false when the external resource exists, but it not up to date
+		// with the desired managed resource state. This lets the managed
+		// resource reconciler know that it needs to call Update.
+		ResourceUpToDate: true,
+
+		// Return any details that may be required to connect to the external
+		// resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.User)
+	if !ok {
+		return managed.ExternalCreation{}, errors.New(errNotUser)
+	}
+
+	user := cloudian.User{
+		GroupUserID: cloudian.GroupUserID{
+			GroupID: cr.Spec.ForProvider.GroupID,
+			UserID:  meta.GetExternalName(mg),
+		},
+		UserType: cloudian.UserTypeStandard,
+	}
+	if err := c.cloudianService.CreateUser(ctx, user); err != nil {
+		return managed.ExternalCreation{}, errors.Wrap(err, errCreateUser)
+	}
+
+	// When Cloudian creates a user, a single access key is created inside it.
+	// Delete the access key, so that the user does not have any non-managed access keys.
+	creds, err := c.cloudianService.ListUserCredentials(ctx, user.GroupUserID)
+	if err != nil {
+		return managed.ExternalCreation{}, errors.Wrap(err, "failed to list access keys of user")
+	}
+	for _, cred := range creds {
+		if err := c.cloudianService.DeleteUserCredentials(ctx, cred.AccessKey); err != nil {
+			return managed.ExternalCreation{}, errors.Wrap(err, "failed to delete initial access key of user")
+		}
+	}
+
+	return managed.ExternalCreation{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.User)
+	if !ok {
+		return managed.ExternalUpdate{}, errors.New(errNotUser)
+	}
+
+	fmt.Printf("Pretending to Update (no managed fields to update): %+v", cr)
+
+	return managed.ExternalUpdate{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.User)
+	if !ok {
+		return managed.ExternalDelete{}, errors.New(errNotUser)
+	}
+
+	guid := cloudian.GroupUserID{
+		GroupID: cr.Spec.ForProvider.GroupID,
+		UserID:  meta.GetExternalName(mg),
+	}
+
+	creds, err := c.cloudianService.ListUserCredentials(ctx, guid)
+	if err != nil {
+		return managed.ExternalDelete{}, err
+	}
+	if len(creds) > 0 {
+		return managed.ExternalDelete{}, errors.New("User has access keys and cannot be deleted")
+	}
+
+	if err := c.cloudianService.DeleteUser(ctx, guid); err != nil {
+		return managed.ExternalDelete{}, errors.Wrap(err, errDeleteUser)
+	}
+
+	return managed.ExternalDelete{}, nil
+}
+
+func (c *external) Disconnect(ctx context.Context) error {
+	return nil
+}

--- a/internal/controller/namespaced/user/user_test.go
+++ b/internal/controller/namespaced/user/user_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package user
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+)
+
+// Unlike many Kubernetes projects Crossplane does not use third party testing
+// libraries, per the common Go test review comments. Crossplane encourages the
+// use of table driven unit tests. The tests of the crossplane-runtime project
+// are representative of the testing style Crossplane encourages.
+//
+// https://github.com/golang/go/wiki/TestComments
+// https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#contributing-code
+
+func TestObserve(t *testing.T) {
+	type fields struct {
+	}
+
+	type args struct {
+		ctx context.Context
+		mg  resource.Managed
+	}
+
+	type want struct {
+		o   managed.ExternalObservation
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		fields fields
+		args   args
+		want   want
+	}{
+		// TODO: Add test cases.
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := external{cloudianService: nil}
+			got, err := e.Observe(tc.args.ctx, tc.args.mg)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.o, got); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/controller/namespaced/userqualityofservicelimits/userqualityofservicelimits.go
+++ b/internal/controller/namespaced/userqualityofservicelimits/userqualityofservicelimits.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userqualityofservicelimits
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/event"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/ratelimiter"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+
+	userv1alpha1namespaced "github.com/statnett/provider-cloudian/apis/namespaced/user/v1alpha1"
+	apisv1alpha1namespaced "github.com/statnett/provider-cloudian/apis/namespaced/v1alpha1"
+	controllercommon "github.com/statnett/provider-cloudian/internal/controller/common"
+	qoslimitscommon "github.com/statnett/provider-cloudian/internal/controller/common/qualityofservicelimits"
+	"github.com/statnett/provider-cloudian/internal/sdk/cloudian"
+)
+
+const (
+	errNotUserQualityOfServiceLimits = "managed resource is not a UserQualityOfServiceLimits custom resource"
+	errTrackPCUsage                  = "cannot track ProviderConfig usage"
+	errGetPC                         = "cannot get ProviderConfig"
+	errGetCreds                      = "cannot get credentials"
+
+	errNewClient = "cannot create new Service"
+	errCreateQOS = "cannot create QOS"
+	errDeleteQOS = "cannot delete QOS"
+	errGetQOS    = "cannot get QOS"
+)
+
+// Setup adds a controller that reconciles UserQualityOfServiceLimits managed resources.
+func Setup(mgr ctrl.Manager, o controller.Options) error {
+	name := managed.ControllerName(userv1alpha1namespaced.UserQualityOfServiceLimitsGroupKind)
+
+	r := managed.NewReconciler(mgr,
+		resource.ManagedKind(userv1alpha1namespaced.UserQualityOfServiceLimitsGroupVersionKind),
+		managed.WithExternalConnector(&connector{
+			kube:         mgr.GetClient(),
+			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1namespaced.ProviderConfigUsage{}),
+			newServiceFn: controllercommon.NewCloudianService,
+		}),
+		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithPollInterval(o.PollInterval),
+		//nolint:staticcheck // SA1004 crossplane-runtime still depends on deprecated API
+		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		WithOptions(o.ForControllerRuntime()).
+		WithEventFilter(resource.DesiredStateChanged()).
+		For(&userv1alpha1namespaced.UserQualityOfServiceLimits{}).
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+}
+
+// A connector is expected to produce an ExternalClient when its Connect method
+// is called.
+type connector struct {
+	kube         client.Client
+	usage        *resource.ProviderConfigUsageTracker
+	newServiceFn func(providerConfigEndpoint string, authHeader string) (*cloudian.Client, error)
+}
+
+// Connect typically produces an ExternalClient by:
+// 1. Tracking that the managed resource is using a ProviderConfig.
+// 2. Getting the managed resource's ProviderConfig.
+// 3. Getting the credentials specified by the ProviderConfig.
+// 4. Using the credentials to form a client.
+func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.UserQualityOfServiceLimits)
+	if !ok {
+		return nil, errors.New(errNotUserQualityOfServiceLimits)
+	}
+
+	if err := c.usage.Track(ctx, cr); err != nil {
+		return nil, errors.Wrap(err, errTrackPCUsage)
+	}
+
+	pc := &apisv1alpha1namespaced.ProviderConfig{}
+	if err := c.kube.Get(ctx, types.NamespacedName{Name: cr.GetProviderConfigReference().Name}, pc); err != nil {
+		return nil, errors.Wrap(err, errGetPC)
+	}
+
+	cd := pc.Spec.AuthHeader
+	authHeader, err := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+	if err != nil {
+		return nil, errors.Wrap(err, errGetCreds)
+	}
+
+	svc, err := c.newServiceFn(pc.Spec.Endpoint, string(authHeader))
+	if err != nil {
+		return nil, errors.Wrap(err, errNewClient)
+	}
+
+	return &external{cloudianService: svc}, nil
+}
+
+// An ExternalClient observes, then either creates, updates, or deletes an
+// external resource to ensure it reflects the managed resource's desired state.
+type external struct {
+	// A 'client' used to connect to the external resource API. In practice this
+	// would be something like an AWS SDK client.
+	cloudianService *cloudian.Client
+}
+
+func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.UserQualityOfServiceLimits)
+	if !ok {
+		return managed.ExternalObservation{}, errors.New(errNotUserQualityOfServiceLimits)
+	}
+
+	groupID := cr.Spec.ForProvider.GroupID
+	if groupID == "" {
+		return managed.ExternalObservation{}, nil
+	}
+	userID := cr.Spec.ForProvider.UserID
+	if userID == "" {
+		return managed.ExternalObservation{}, nil
+	}
+
+	guid := cloudian.GroupUserID{
+		GroupID: groupID,
+		UserID:  userID,
+	}
+	qos, err := c.cloudianService.GetQOS(ctx, guid, cr.Spec.ForProvider.Region)
+
+	if errors.Is(err, cloudian.ErrNotFound) {
+		return managed.ExternalObservation{ResourceExists: false}, nil
+	}
+	if err != nil {
+		return managed.ExternalObservation{}, errors.Wrap(err, errGetQOS)
+	}
+
+	cr.SetConditions(xpv2.Available())
+
+	expected, err := qoslimitscommon.ToCloudianQOS(cr.Spec.ForProvider.QOS)
+	if err != nil {
+		return managed.ExternalObservation{}, err
+	}
+
+	return managed.ExternalObservation{
+		// Return false when the external resource does not exist. This lets
+		// the managed resource reconciler know that it needs to call Create to
+		// (re)create the resource, or that it has successfully been deleted.
+		ResourceExists: true,
+
+		// Return false when the external resource exists, but it not up to date
+		// with the desired managed resource state. This lets the managed
+		// resource reconciler know that it needs to call Update.
+		ResourceUpToDate: expected.Warning.Equal(qos.Warning) &&
+			expected.Hard.Equal(qos.Hard),
+
+		// Return any details that may be required to connect to the external
+		// resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.UserQualityOfServiceLimits)
+	if !ok {
+		return managed.ExternalCreation{}, errors.New(errNotUserQualityOfServiceLimits)
+	}
+
+	qos, err := qoslimitscommon.ToCloudianQOS(cr.Spec.ForProvider.QOS)
+	if err != nil {
+		return managed.ExternalCreation{}, err
+	}
+
+	guid := cloudian.GroupUserID{
+		GroupID: cr.Spec.ForProvider.GroupID,
+		UserID:  cr.Spec.ForProvider.UserID,
+	}
+	if err := c.cloudianService.SetQOS(ctx, guid, cr.Spec.ForProvider.Region, qos); err != nil {
+		return managed.ExternalCreation{}, errors.Wrap(err, errCreateQOS)
+	}
+
+	return managed.ExternalCreation{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.UserQualityOfServiceLimits)
+	if !ok {
+		return managed.ExternalUpdate{}, errors.New(errNotUserQualityOfServiceLimits)
+	}
+
+	qos, err := qoslimitscommon.ToCloudianQOS(cr.Spec.ForProvider.QOS)
+	if err != nil {
+		return managed.ExternalUpdate{}, err
+	}
+
+	guid := cloudian.GroupUserID{
+		GroupID: cr.Spec.ForProvider.GroupID,
+		UserID:  cr.Spec.ForProvider.UserID,
+	}
+	if err := c.cloudianService.SetQOS(ctx, guid, cr.Spec.ForProvider.Region, qos); err != nil {
+		return managed.ExternalUpdate{}, errors.Wrap(err, errCreateQOS)
+	}
+
+	return managed.ExternalUpdate{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {
+	cr, ok := mg.(*userv1alpha1namespaced.UserQualityOfServiceLimits)
+	if !ok {
+		return managed.ExternalDelete{}, errors.New(errNotUserQualityOfServiceLimits)
+	}
+
+	cr.SetConditions(xpv2.Deleting())
+
+	guid := cloudian.GroupUserID{
+		GroupID: cr.Spec.ForProvider.GroupID,
+		UserID:  cr.Spec.ForProvider.UserID,
+	}
+	err := c.cloudianService.DeleteQOS(ctx, guid, cr.Spec.ForProvider.Region)
+	if err != nil && !errors.Is(err, cloudian.ErrNotFound) {
+		return managed.ExternalDelete{}, errors.Wrap(err, errGetCreds)
+	}
+
+	return managed.ExternalDelete{}, nil
+}
+
+func (c *external) Disconnect(ctx context.Context) error {
+	return nil
+}

--- a/internal/controller/namespaced/userqualityofservicelimits/userqualityofservicelimits_test.go
+++ b/internal/controller/namespaced/userqualityofservicelimits/userqualityofservicelimits_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userqualityofservicelimits
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+)
+
+// Unlike many Kubernetes projects Crossplane does not use third party testing
+// libraries, per the common Go test review comments. Crossplane encourages the
+// use of table driven unit tests. The tests of the crossplane-runtime project
+// are representative of the testing style Crossplane encourages.
+//
+// https://github.com/golang/go/wiki/TestComments
+// https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#contributing-code
+
+func TestObserve(t *testing.T) {
+	type fields struct {
+	}
+
+	type args struct {
+		ctx context.Context
+		mg  resource.Managed
+	}
+
+	type want struct {
+		o   managed.ExternalObservation
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		fields fields
+		args   args
+		want   want
+	}{
+		// TODO: Add test cases.
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := external{}
+			got, err := e.Observe(tc.args.ctx, tc.args.mg)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.o, got); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Mirrors [this commit](https://github.com/upbound/provider-upbound/commit/58d6fdf10ada9a5beb4ce43621a8286e7f7d9f77#diff-82f49111d1a6fc5f22f88c8b05636f649e07a74bd9556e0fd51d561e41a1715f) from Upbound.

They also add some of the common resources we've added in previous PRs.