### PR TITLE
fix: correct group for namespaced resources

### DIFF
--- a/apis/namespaced/user/v1alpha1/groupversion_info.go
+++ b/apis/namespaced/user/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains the v1alpha1 group Sample resources of the Cloudian provider.
 // +kubebuilder:object:generate=true
-// +groupName=user.m.cloudian.crossplane.io
+// +groupName=user.cloudian.m.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1
 
@@ -28,7 +28,7 @@ import (
 
 // Package type metadata.
 const (
-	MetadataGroup = "user.m.cloudian.crossplane.io"
+	MetadataGroup = "user.cloudian.m.crossplane.io"
 	Version       = "v1alpha1"
 )
 

--- a/apis/namespaced/v1alpha1/groupversion_info.go
+++ b/apis/namespaced/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains the core resources of the Cloudian provider.
 // +kubebuilder:object:generate=true
-// +groupName=m.cloudian.crossplane.io
+// +groupName=cloudian.m.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1
 
@@ -28,7 +28,7 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "m.cloudian.crossplane.io"
+	Group   = "cloudian.m.crossplane.io"
 	Version = "v1alpha1"
 )
 

--- a/package/crds/cloudian.m.crossplane.io_clusterproviderconfigs.yaml
+++ b/package/crds/cloudian.m.crossplane.io_clusterproviderconfigs.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
-  name: clusterproviderconfigs.m.cloudian.crossplane.io
+  name: clusterproviderconfigs.cloudian.m.crossplane.io
 spec:
-  group: m.cloudian.crossplane.io
+  group: cloudian.m.crossplane.io
   names:
     categories:
     - crossplane

--- a/package/crds/cloudian.m.crossplane.io_clusterproviderconfigusages.yaml
+++ b/package/crds/cloudian.m.crossplane.io_clusterproviderconfigusages.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
-  name: clusterproviderconfigusages.m.cloudian.crossplane.io
+  name: clusterproviderconfigusages.cloudian.m.crossplane.io
 spec:
-  group: m.cloudian.crossplane.io
+  group: cloudian.m.crossplane.io
   names:
     categories:
     - crossplane

--- a/package/crds/cloudian.m.crossplane.io_providerconfigs.yaml
+++ b/package/crds/cloudian.m.crossplane.io_providerconfigs.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
-  name: providerconfigs.m.cloudian.crossplane.io
+  name: providerconfigs.cloudian.m.crossplane.io
 spec:
-  group: m.cloudian.crossplane.io
+  group: cloudian.m.crossplane.io
   names:
     categories:
     - crossplane

--- a/package/crds/cloudian.m.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/cloudian.m.crossplane.io_providerconfigusages.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
-  name: providerconfigusages.m.cloudian.crossplane.io
+  name: providerconfigusages.cloudian.m.crossplane.io
 spec:
-  group: m.cloudian.crossplane.io
+  group: cloudian.m.crossplane.io
   names:
     categories:
     - crossplane

--- a/package/crds/user.cloudian.m.crossplane.io_accesskeys.yaml
+++ b/package/crds/user.cloudian.m.crossplane.io_accesskeys.yaml
@@ -4,18 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
-  name: groups.user.m.cloudian.crossplane.io
+  name: accesskeys.user.cloudian.m.crossplane.io
 spec:
-  group: user.m.cloudian.crossplane.io
+  group: user.cloudian.m.crossplane.io
   names:
     categories:
     - crossplane
     - managed
     - cloudian
-    kind: Group
-    listKind: GroupList
-    plural: groups
-    singular: group
+    kind: AccessKey
+    listKind: AccessKeyList
+    plural: accesskeys
+    singular: accesskey
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -34,7 +34,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Group represents a Cloudian group.
+        description: AccessKey represents an access key for a Cloudian user.
         properties:
           apiVersion:
             description: |-
@@ -54,48 +54,94 @@ spec:
           metadata:
             type: object
           spec:
-            description: A GroupSpec defines the desired state of a Group.
+            description: A AccessKeySpec defines the desired state of a AccessKey.
             properties:
               forProvider:
-                description: GroupParameters are the configurable fields of a Group.
+                description: AccessKeyParameters are the configurable fields of a
+                  AccessKey.
                 properties:
-                  active:
-                    default: true
-                    description: Active determines whether the group is enabled (true)
-                      or disabled (false) in the system.
-                    type: boolean
-                  groupName:
-                    description: GroupName is the group name (known as Description
-                      in the GUI).
-                    maxLength: 64
+                  groupId:
+                    description: GroupID of the access key.
                     type: string
-                  ldapEnabled:
-                    default: false
-                    description: LDAPEnabled determines whether LDAP authentication
-                      is enabled for members of this group.
-                    type: boolean
-                  ldapGroup:
-                    description: LDAPGroup us the group's name from the LDAP system.
+                  userId:
+                    description: UserId of the access key.
                     type: string
-                  ldapMatchAttribute:
-                    type: string
-                  ldapSearch:
-                    type: string
-                  ldapSearchUserBase:
-                    description: LDAPSearchUserBase specifies the LDAP search base
-                      from which the CMC should start when retrieving the user's LDAP
-                      record in order to apply filtering.
-                    type: string
-                  ldapServerURL:
-                    description: LDAPServerURL specifies the URL that the CMC should
-                      use to access the LDAP Server when authenticating users in this
-                      group.
-                    type: string
-                  ldapUserDNTemplate:
-                    description: LDAPUserDNTemplate specifies how users within this
-                      group will be authenticated against the LDAP system when they
-                      log into the CMC.
-                    type: string
+                  userIdRef:
+                    description: UserIDRef references a user to retrieve its groupId
+                      and userId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  userIdSelector:
+                    description: UserIDSelector selects a user to retrieve its groupId
+                      and userId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                 type: object
               managementPolicies:
                 default:
@@ -156,10 +202,15 @@ spec:
             - forProvider
             type: object
           status:
-            description: A GroupStatus represents the observed state of a Group.
+            description: A AccessKeyStatus represents the observed state of a AccessKey.
             properties:
               atProvider:
-                description: GroupObservation are the observable fields of a Group.
+                description: AccessKeyObservation are the observable fields of a AccessKey.
+                properties:
+                  id:
+                    description: ID is the S3 Access Key ID, with a corresponding
+                      SecretKey.
+                    type: string
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/user.cloudian.m.crossplane.io_groupqualityofservicelimits.yaml
+++ b/package/crds/user.cloudian.m.crossplane.io_groupqualityofservicelimits.yaml
@@ -4,18 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
-  name: userqualityofservicelimits.user.m.cloudian.crossplane.io
+  name: groupqualityofservicelimits.user.cloudian.m.crossplane.io
 spec:
-  group: user.m.cloudian.crossplane.io
+  group: user.cloudian.m.crossplane.io
   names:
     categories:
     - crossplane
     - managed
     - cloudian
-    kind: UserQualityOfServiceLimits
-    listKind: UserQualityOfServiceLimitsList
-    plural: userqualityofservicelimits
-    singular: userqualityofservicelimits
+    kind: GroupQualityOfServiceLimits
+    listKind: GroupQualityOfServiceLimitsList
+    plural: groupqualityofservicelimits
+    singular: groupqualityofservicelimits
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -34,8 +34,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: UserQualityOfServiceLimits represents the quality of service
-          limits for a Cloudian user, within a region.
+        description: GroupQualityOfServiceLimits represents the quality of service
+          limits for a Cloudian group, within a region.
         properties:
           apiVersion:
             description: |-
@@ -55,60 +55,18 @@ spec:
           metadata:
             type: object
           spec:
-            description: A UserQualityOfServiceLimitsSpec defines the desired state
-              of a UserQualityOfServiceLimits.
+            description: A GroupQualityOfServiceLimitsSpec defines the desired state
+              of a GroupQualityOfServiceLimits.
             properties:
               forProvider:
-                description: UserQualityOfServiceLimitsParameters are the configurable
-                  fields of a UserQualityOfServiceLimits.
+                description: GroupQualityOfServiceLimitsParameters are the configurable
+                  fields of a GroupQualityOfServiceLimits.
                 properties:
                   groupId:
                     description: GroupID of the quality of service limits.
                     type: string
-                  hard:
-                    description: Hard is the hard limit.
-                    properties:
-                      inboundBytesPerMin:
-                        description: InboundBytesPerMin is the limit for inbound data
-                          per minute in bytes.
-                        nullable: true
-                        pattern: ^(0|((0|[1-9][0-9]*)[KMGT]i))$
-                        type: string
-                      outboundBytesPerMin:
-                        description: OutboundKiBsPerMin is the limit for outbound
-                          data per minute in bytes.
-                        nullable: true
-                        pattern: ^(0|((0|[1-9][0-9]*)[KMGT]i))$
-                        type: string
-                      requestsPerMin:
-                        description: RequestsPerMin is the limit for number of HTTP
-                          requests per minute.
-                        format: int32
-                        nullable: true
-                        type: integer
-                      storageQuotaBytes:
-                        description: StorageQuotaBytes is the limit for total stored
-                          data in bytes.
-                        nullable: true
-                        pattern: ^(0|((0|[1-9][0-9]*)[KMGT]i))$
-                        type: string
-                      storageQuotaCount:
-                        description: StorageQuotaCount is the limit for total number
-                          of objects.
-                        format: int32
-                        nullable: true
-                        type: integer
-                    type: object
-                  region:
-                    description: Region in which to apply the quality of service limits.
-                      Default region if unspecified.
-                    type: string
-                  userId:
-                    description: UserID of the quality of service limits.
-                    type: string
-                  userIdRef:
-                    description: UserIDRef references a user to retrieve its groupId
-                      and userId.
+                  groupIdRef:
+                    description: GroupIDRef references a group to retrieve its groupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -141,9 +99,8 @@ spec:
                     required:
                     - name
                     type: object
-                  userIdSelector:
-                    description: UserIDSelector selects a user to retrieve its groupId
-                      and userId.
+                  groupIdSelector:
+                    description: GroupIDSelector selects a group to retrieve its groupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -182,6 +139,44 @@ spec:
                             type: string
                         type: object
                     type: object
+                  hard:
+                    description: Hard is the hard limit.
+                    properties:
+                      inboundBytesPerMin:
+                        description: InboundBytesPerMin is the limit for inbound data
+                          per minute in bytes.
+                        nullable: true
+                        pattern: ^(0|((0|[1-9][0-9]*)[KMGT]i))$
+                        type: string
+                      outboundBytesPerMin:
+                        description: OutboundKiBsPerMin is the limit for outbound
+                          data per minute in bytes.
+                        nullable: true
+                        pattern: ^(0|((0|[1-9][0-9]*)[KMGT]i))$
+                        type: string
+                      requestsPerMin:
+                        description: RequestsPerMin is the limit for number of HTTP
+                          requests per minute.
+                        format: int32
+                        nullable: true
+                        type: integer
+                      storageQuotaBytes:
+                        description: StorageQuotaBytes is the limit for total stored
+                          data in bytes.
+                        nullable: true
+                        pattern: ^(0|((0|[1-9][0-9]*)[KMGT]i))$
+                        type: string
+                      storageQuotaCount:
+                        description: StorageQuotaCount is the limit for total number
+                          of objects.
+                        format: int32
+                        nullable: true
+                        type: integer
+                    type: object
+                  region:
+                    description: Region in which to apply the quality of service limits.
+                      Default region if unspecified.
+                    type: string
                   warning:
                     description: Warning is the soft limit that triggers a warning.
                     properties:
@@ -276,12 +271,12 @@ spec:
             - forProvider
             type: object
           status:
-            description: A UserQualityOfServiceLimitsStatus represents the observed
-              state of a UserQualityOfServiceLimits.
+            description: A GroupQualityOfServiceLimitsStatus represents the observed
+              state of a GroupQualityOfServiceLimits.
             properties:
               atProvider:
-                description: UserQualityOfServiceLimitsObservation are the observable
-                  fields of a UserQualityOfServiceLimits.
+                description: GroupQualityOfServiceLimitsObservation are the observable
+                  fields of a GroupQualityOfServiceLimits.
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/user.cloudian.m.crossplane.io_groups.yaml
+++ b/package/crds/user.cloudian.m.crossplane.io_groups.yaml
@@ -4,18 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
-  name: users.user.m.cloudian.crossplane.io
+  name: groups.user.cloudian.m.crossplane.io
 spec:
-  group: user.m.cloudian.crossplane.io
+  group: user.cloudian.m.crossplane.io
   names:
     categories:
     - crossplane
     - managed
     - cloudian
-    kind: User
-    listKind: UserList
-    plural: users
-    singular: user
+    kind: Group
+    listKind: GroupList
+    plural: groups
+    singular: group
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -34,7 +34,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: User represents a Cloudian user.
+        description: Group represents a Cloudian group.
         properties:
           apiVersion:
             description: |-
@@ -54,90 +54,48 @@ spec:
           metadata:
             type: object
           spec:
-            description: A UserSpec defines the desired state of a User.
+            description: A GroupSpec defines the desired state of a Group.
             properties:
               forProvider:
-                description: UserParameters are the configurable fields of a User.
+                description: GroupParameters are the configurable fields of a Group.
                 properties:
-                  groupId:
-                    description: Group for the new user.
+                  active:
+                    default: true
+                    description: Active determines whether the group is enabled (true)
+                      or disabled (false) in the system.
+                    type: boolean
+                  groupName:
+                    description: GroupName is the group name (known as Description
+                      in the GUI).
+                    maxLength: 64
                     type: string
-                  groupIdRef:
-                    description: GroupIDRef is a reference to a group to retrieve
-                      its groupId.
-                    properties:
-                      name:
-                        description: Name of the referenced object.
-                        type: string
-                      policy:
-                        description: Policies for referencing.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: |-
-                              Resolution specifies whether resolution of this reference is required.
-                              The default is 'Required', which means the reconcile will fail if the
-                              reference cannot be resolved. 'Optional' means this reference will be
-                              a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: |-
-                              Resolve specifies when this reference should be resolved. The default
-                              is 'IfNotPresent', which will attempt to resolve the reference only when
-                              the corresponding field is not present. Use 'Always' to resolve the
-                              reference on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  groupIdSelector:
-                    description: GroupIDSelector selects reference to a group to retrieve
-                      its groupId.
-                    properties:
-                      matchControllerRef:
-                        description: |-
-                          MatchControllerRef ensures an object with the same controller reference
-                          as the selecting object is selected.
-                        type: boolean
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: MatchLabels ensures an object with matching labels
-                          is selected.
-                        type: object
-                      policy:
-                        description: Policies for selection.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: |-
-                              Resolution specifies whether resolution of this reference is required.
-                              The default is 'Required', which means the reconcile will fail if the
-                              reference cannot be resolved. 'Optional' means this reference will be
-                              a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: |-
-                              Resolve specifies when this reference should be resolved. The default
-                              is 'IfNotPresent', which will attempt to resolve the reference only when
-                              the corresponding field is not present. Use 'Always' to resolve the
-                              reference on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    type: object
+                  ldapEnabled:
+                    default: false
+                    description: LDAPEnabled determines whether LDAP authentication
+                      is enabled for members of this group.
+                    type: boolean
+                  ldapGroup:
+                    description: LDAPGroup us the group's name from the LDAP system.
+                    type: string
+                  ldapMatchAttribute:
+                    type: string
+                  ldapSearch:
+                    type: string
+                  ldapSearchUserBase:
+                    description: LDAPSearchUserBase specifies the LDAP search base
+                      from which the CMC should start when retrieving the user's LDAP
+                      record in order to apply filtering.
+                    type: string
+                  ldapServerURL:
+                    description: LDAPServerURL specifies the URL that the CMC should
+                      use to access the LDAP Server when authenticating users in this
+                      group.
+                    type: string
+                  ldapUserDNTemplate:
+                    description: LDAPUserDNTemplate specifies how users within this
+                      group will be authenticated against the LDAP system when they
+                      log into the CMC.
+                    type: string
                 type: object
               managementPolicies:
                 default:
@@ -198,13 +156,10 @@ spec:
             - forProvider
             type: object
           status:
-            description: A UserStatus represents the observed state of a User.
+            description: A GroupStatus represents the observed state of a Group.
             properties:
               atProvider:
-                description: UserObservation are the observable fields of a User.
-                properties:
-                  canonicalId:
-                    type: string
+                description: GroupObservation are the observable fields of a Group.
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/user.cloudian.m.crossplane.io_userqualityofservicelimits.yaml
+++ b/package/crds/user.cloudian.m.crossplane.io_userqualityofservicelimits.yaml
@@ -4,18 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
-  name: groupqualityofservicelimits.user.m.cloudian.crossplane.io
+  name: userqualityofservicelimits.user.cloudian.m.crossplane.io
 spec:
-  group: user.m.cloudian.crossplane.io
+  group: user.cloudian.m.crossplane.io
   names:
     categories:
     - crossplane
     - managed
     - cloudian
-    kind: GroupQualityOfServiceLimits
-    listKind: GroupQualityOfServiceLimitsList
-    plural: groupqualityofservicelimits
-    singular: groupqualityofservicelimits
+    kind: UserQualityOfServiceLimits
+    listKind: UserQualityOfServiceLimitsList
+    plural: userqualityofservicelimits
+    singular: userqualityofservicelimits
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -34,8 +34,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: GroupQualityOfServiceLimits represents the quality of service
-          limits for a Cloudian group, within a region.
+        description: UserQualityOfServiceLimits represents the quality of service
+          limits for a Cloudian user, within a region.
         properties:
           apiVersion:
             description: |-
@@ -55,90 +55,16 @@ spec:
           metadata:
             type: object
           spec:
-            description: A GroupQualityOfServiceLimitsSpec defines the desired state
-              of a GroupQualityOfServiceLimits.
+            description: A UserQualityOfServiceLimitsSpec defines the desired state
+              of a UserQualityOfServiceLimits.
             properties:
               forProvider:
-                description: GroupQualityOfServiceLimitsParameters are the configurable
-                  fields of a GroupQualityOfServiceLimits.
+                description: UserQualityOfServiceLimitsParameters are the configurable
+                  fields of a UserQualityOfServiceLimits.
                 properties:
                   groupId:
                     description: GroupID of the quality of service limits.
                     type: string
-                  groupIdRef:
-                    description: GroupIDRef references a group to retrieve its groupId.
-                    properties:
-                      name:
-                        description: Name of the referenced object.
-                        type: string
-                      policy:
-                        description: Policies for referencing.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: |-
-                              Resolution specifies whether resolution of this reference is required.
-                              The default is 'Required', which means the reconcile will fail if the
-                              reference cannot be resolved. 'Optional' means this reference will be
-                              a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: |-
-                              Resolve specifies when this reference should be resolved. The default
-                              is 'IfNotPresent', which will attempt to resolve the reference only when
-                              the corresponding field is not present. Use 'Always' to resolve the
-                              reference on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  groupIdSelector:
-                    description: GroupIDSelector selects a group to retrieve its groupId.
-                    properties:
-                      matchControllerRef:
-                        description: |-
-                          MatchControllerRef ensures an object with the same controller reference
-                          as the selecting object is selected.
-                        type: boolean
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: MatchLabels ensures an object with matching labels
-                          is selected.
-                        type: object
-                      policy:
-                        description: Policies for selection.
-                        properties:
-                          resolution:
-                            default: Required
-                            description: |-
-                              Resolution specifies whether resolution of this reference is required.
-                              The default is 'Required', which means the reconcile will fail if the
-                              reference cannot be resolved. 'Optional' means this reference will be
-                              a no-op if it cannot be resolved.
-                            enum:
-                            - Required
-                            - Optional
-                            type: string
-                          resolve:
-                            description: |-
-                              Resolve specifies when this reference should be resolved. The default
-                              is 'IfNotPresent', which will attempt to resolve the reference only when
-                              the corresponding field is not present. Use 'Always' to resolve the
-                              reference on every reconcile.
-                            enum:
-                            - Always
-                            - IfNotPresent
-                            type: string
-                        type: object
-                    type: object
                   hard:
                     description: Hard is the hard limit.
                     properties:
@@ -177,6 +103,85 @@ spec:
                     description: Region in which to apply the quality of service limits.
                       Default region if unspecified.
                     type: string
+                  userId:
+                    description: UserID of the quality of service limits.
+                    type: string
+                  userIdRef:
+                    description: UserIDRef references a user to retrieve its groupId
+                      and userId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  userIdSelector:
+                    description: UserIDSelector selects a user to retrieve its groupId
+                      and userId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   warning:
                     description: Warning is the soft limit that triggers a warning.
                     properties:
@@ -271,12 +276,12 @@ spec:
             - forProvider
             type: object
           status:
-            description: A GroupQualityOfServiceLimitsStatus represents the observed
-              state of a GroupQualityOfServiceLimits.
+            description: A UserQualityOfServiceLimitsStatus represents the observed
+              state of a UserQualityOfServiceLimits.
             properties:
               atProvider:
-                description: GroupQualityOfServiceLimitsObservation are the observable
-                  fields of a GroupQualityOfServiceLimits.
+                description: UserQualityOfServiceLimitsObservation are the observable
+                  fields of a UserQualityOfServiceLimits.
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/user.cloudian.m.crossplane.io_users.yaml
+++ b/package/crds/user.cloudian.m.crossplane.io_users.yaml
@@ -4,18 +4,18 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
-  name: accesskeys.user.m.cloudian.crossplane.io
+  name: users.user.cloudian.m.crossplane.io
 spec:
-  group: user.m.cloudian.crossplane.io
+  group: user.cloudian.m.crossplane.io
   names:
     categories:
     - crossplane
     - managed
     - cloudian
-    kind: AccessKey
-    listKind: AccessKeyList
-    plural: accesskeys
-    singular: accesskey
+    kind: User
+    listKind: UserList
+    plural: users
+    singular: user
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -34,7 +34,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AccessKey represents an access key for a Cloudian user.
+        description: User represents a Cloudian user.
         properties:
           apiVersion:
             description: |-
@@ -54,21 +54,17 @@ spec:
           metadata:
             type: object
           spec:
-            description: A AccessKeySpec defines the desired state of a AccessKey.
+            description: A UserSpec defines the desired state of a User.
             properties:
               forProvider:
-                description: AccessKeyParameters are the configurable fields of a
-                  AccessKey.
+                description: UserParameters are the configurable fields of a User.
                 properties:
                   groupId:
-                    description: GroupID of the access key.
+                    description: Group for the new user.
                     type: string
-                  userId:
-                    description: UserId of the access key.
-                    type: string
-                  userIdRef:
-                    description: UserIDRef references a user to retrieve its groupId
-                      and userId.
+                  groupIdRef:
+                    description: GroupIDRef is a reference to a group to retrieve
+                      its groupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -101,9 +97,9 @@ spec:
                     required:
                     - name
                     type: object
-                  userIdSelector:
-                    description: UserIDSelector selects a user to retrieve its groupId
-                      and userId.
+                  groupIdSelector:
+                    description: GroupIDSelector selects reference to a group to retrieve
+                      its groupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -202,14 +198,12 @@ spec:
             - forProvider
             type: object
           status:
-            description: A AccessKeyStatus represents the observed state of a AccessKey.
+            description: A UserStatus represents the observed state of a User.
             properties:
               atProvider:
-                description: AccessKeyObservation are the observable fields of a AccessKey.
+                description: UserObservation are the observable fields of a User.
                 properties:
-                  id:
-                    description: ID is the S3 Access Key ID, with a corresponding
-                      SecretKey.
+                  canonicalId:
                     type: string
                 type: object
               conditions:


### PR DESCRIPTION
It seems like `<provider>.m.crossplane.io` is the common base group name pattern for Crossplane provider namespaced resources, and not` m.<provider>.crossplane.io`.