### PR TITLE
fix: panic in non-safe start

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -159,8 +159,8 @@ func main() {
 
 	if canSafeStart {
 		o.Gate = new(gate.Gate[schema.GroupVersionKind])
-		kingpin.FatalIfError(controllercluster.Setup(mgr, o), "Cannot setup Cluster Cloudian controllers")
-		kingpin.FatalIfError(controllernamespaced.Setup(mgr, o), "Cannot setup Namespaced Cloudian controllers")
+		kingpin.FatalIfError(controllercluster.SetupGated(mgr, o), "Cannot setup Cluster Cloudian controllers")
+		kingpin.FatalIfError(controllernamespaced.SetupGated(mgr, o), "Cannot setup Namespaced Cloudian controllers")
 		kingpin.FatalIfError(customresourcesgate.Setup(mgr, o), "Cannot setup CRD gate controller")
 	} else {
 		log.Info("Provider has missing RBAC permissions for watching CRDs, controller SafeStart capability will be disabled")

--- a/internal/controller/cluster/cluster.go
+++ b/internal/controller/cluster/cluster.go
@@ -32,6 +32,24 @@ import (
 // with the supplied logger and adds them to the supplied manager.
 func Setup(mgr ctrl.Manager, o controller.Options) error {
 	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+		accesskey.Setup,
+		config.Setup,
+		group.Setup,
+		groupqualityofservicelimits.Setup,
+		user.Setup,
+		userqualityofservicelimits.Setup,
+	} {
+		if err := setup(mgr, o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Setup creates all Cloudian controllers related to cluster scoped MRs
+// with safe-start support and adds them to the supplied manager.
+func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+	for _, setup := range []func(ctrl.Manager, controller.Options) error{
 		accesskey.SetupGated,
 		config.SetupGated,
 		group.SetupGated,

--- a/internal/controller/cluster/cluster.go
+++ b/internal/controller/cluster/cluster.go
@@ -46,7 +46,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 	return nil
 }
 
-// Setup creates all Cloudian controllers related to cluster scoped MRs
+// SetupGated creates all Cloudian controllers related to cluster scoped MRs
 // with safe-start support and adds them to the supplied manager.
 func SetupGated(mgr ctrl.Manager, o controller.Options) error {
 	for _, setup := range []func(ctrl.Manager, controller.Options) error{

--- a/internal/controller/namespaced/namespaced.go
+++ b/internal/controller/namespaced/namespaced.go
@@ -46,7 +46,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 	return nil
 }
 
-// Setup creates all Cloudian controllers with safe-start support
+// SetupGated creates all Cloudian controllers with safe-start support
 // and adds them to the supplied manager.
 func SetupGated(mgr ctrl.Manager, o controller.Options) error {
 	for _, setup := range []func(ctrl.Manager, controller.Options) error{

--- a/internal/controller/namespaced/namespaced.go
+++ b/internal/controller/namespaced/namespaced.go
@@ -32,6 +32,24 @@ import (
 // the supplied manager.
 func Setup(mgr ctrl.Manager, o controller.Options) error {
 	for _, setup := range []func(ctrl.Manager, controller.Options) error{
+		accesskey.Setup,
+		config.Setup,
+		group.Setup,
+		groupqualityofservicelimits.Setup,
+		user.Setup,
+		userqualityofservicelimits.Setup,
+	} {
+		if err := setup(mgr, o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Setup creates all Cloudian controllers with safe-start support
+// and adds them to the supplied manager.
+func SetupGated(mgr ctrl.Manager, o controller.Options) error {
+	for _, setup := range []func(ctrl.Manager, controller.Options) error{
 		accesskey.SetupGated,
 		config.SetupGated,
 		group.SetupGated,


### PR DESCRIPTION
When testing the safe-start implementation, I noticed the following panic:

````
2026-06-19T06:22:05Z        INFO        provider-cloudian        Beta feature enabled        {"flag": "EnableBetaManagementPolicies"}
2026-06-19T06:22:05Z        INFO        provider-cloudian        Provider has missing RBAC permissions for watching CRDs, controller SafeStart capability will be disabled
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x180ac96]
goroutine 1 [running]:
github.com/statnett/provider-cloudian/internal/controller/cluster/accesskey.SetupGated({0x1e85d18, 0x2b9c385d23c0}, {{0x1e6b1a8, 0x2b9c387893c8}, {0x1e6b178, 0x2b9c388023e8}, 0xdf8475800, 0xa, 0x2b9c38506700, 0x0, ...})
        github.com/statnett/provider-cloudian/internal/controller/cluster/accesskey/accesskey.go:56 +0x156
github.com/statnett/provider-cloudian/internal/controller/cluster.Setup({0x1e85d18, 0x2b9c385d23c0}, {{0x1e6b1a8, 0x2b9c387893c8}, {0x1e6b178, 0x2b9c388023e8}, 0xdf8475800, 0xa, 0x2b9c38506700, 0x0, ...})
        github.com/statnett/provider-cloudian/internal/controller/cluster/cluster.go:42 +0x11b
main.main()
        github.com/statnett/provider-cloudian/cmd/provider/main.go:167 +0x2185
````

I have to look more into the RBAC issue, but this should fix the panic.