### PR TITLE
fix: provider capabilities

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -10,4 +10,4 @@ metadata:
       A Crossplane provider for Cloudian.
 spec:
   capabilities:
-    - safe-start
+    - SafeStart


### PR DESCRIPTION
both `xpkg.crossplane.io/crossplane-contrib/provider-family-azure:v2.6.0` and `xpkg.crossplane.io/crossplane-contrib/provider-gitlab:v0.20.0` use this format